### PR TITLE
Accelerate computation of integral matrix for photoproduction moments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.root*
 *_dictUmbrella.h
 *_dictContent.h
+*_dict.cxx_tmp*
 .nfs*
 screen
 .proof

--- a/testBasisFunc.py
+++ b/testBasisFunc.py
@@ -5,6 +5,7 @@ os.environ["OMP_NUM_THREADS"] = "5"  # limit number of OpenMP threads; see also 
 
 import functools
 import numpy as np
+import subprocess
 
 import ROOT
 
@@ -44,7 +45,29 @@ def enableRootACLiCOpenMp():
   elif "linux" in arch.lower():
     print(f"Enabling ACLiC compilation with OpenMP for Linux")
     ROOT.gSystem.SetFlagsOpt("-fopenmp")  # compiler flags for optimized mode  # type: ignore
-    ROOT.gSystem.AddLinkedLibs("-lomp")  # type: ignore
+    ROOT.gSystem.AddLinkedLibs("-lgomp")  # type: ignore
+    # For usual setups, the above should be sufficient.
+    # On ifarm, however, ROOT seems to be compiled with a weird gcc setup.
+    # ACLiC does not search the gcc include directory at `/usr/lib/gcc/x86_64-redhat-linux/4.8.5/include`.`
+    # Instead, it seems to go to /usr/lib/gcc/x86_64-redhat-linux/4.8.5/../../../../include/c++/4.8.5/,
+    # which is /usr/include/c++/4.8.5/ but does not contain omp.h.
+    # There seems to be no way to fix this without changing the source code.
+    # ACLiC always complaints that it cannot find `omp.h`.`
+    # # get gcc include directory
+    # result = subprocess.run("gcc -print-search-dirs",
+    #                         shell = True, stdout = subprocess.PIPE, stderr = subprocess.STDOUT, universal_newlines = True)
+    # lines= result.stdout.split("\n")
+    # gccIncludePath = None
+    # for line in lines:
+    #   if "install:" in line:
+    #     gccIncludePath = line.split(": ")[1] + "include"
+    # ROOT.gSystem.AddIncludePath(f"-I \"{gccIncludePath}\"")  # this causes compile errors because it clashes with headers in `/usr/include/c++/4.8.5/`, which weirdly does not contain `omp.h``  # type: ignore
+    # ROOT.gSystem.AddIncludePath(f"-idirafter \"{gccIncludePath}\"")  # this has no effect # type: ignore
+    # ROOT.gSystem.AddIncludePath(f"-isystem \"{gccIncludePath}\"")  # this has no effect # type: ignore
+    #
+    # The only way to make it work is to copy/link `omp.h`` from the
+    # gcc include dir here and turn the system include statement in
+    # `wigner.C`` into the quoted form.
 enableRootACLiCOpenMp()
 
 

--- a/testBasisFunc.py
+++ b/testBasisFunc.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+import os
+os.environ["OMP_NUM_THREADS"] = "5"  # limit number of OpenMP threads; see also threadpoolctl
+
 import functools
 import numpy as np
 
@@ -10,6 +13,34 @@ import ROOT
 print = functools.partial(print, flush = True)
 
 
+def printRootACLiCSettings():
+  '''Prints ROOT settings that affect ACLiC compilation'''
+  print(f" GetBuildArch()               = {ROOT.gSystem.GetBuildArch()}")  # type: ignore
+  print(f" GetBuildCompiler()           = {ROOT.gSystem.GetBuildCompiler()}")  # type: ignore
+  print(f" GetBuildCompilerVersion()    = {ROOT.gSystem.GetBuildCompilerVersion()}")  # type: ignore
+  print(f" GetBuildCompilerVersionStr() = {ROOT.gSystem.GetBuildCompilerVersionStr()}")  # type: ignore
+  print(f" GetBuildDir()                = {ROOT.gSystem.GetBuildDir()}")  # type: ignore
+  print(f" GetFlagsDebug()              = {ROOT.gSystem.GetFlagsDebug()}")  # type: ignore
+  print(f" GetFlagsOpt()                = {ROOT.gSystem.GetFlagsOpt()}")  # type: ignore
+  print(f" GetIncludePath()             = {ROOT.gSystem.GetIncludePath()}")  # type: ignore
+  print(f" GetDynamicPath()             = {ROOT.gSystem.GetDynamicPath()}")  # type: ignore
+  print(f" GetLinkedLibs()              = {ROOT.gSystem.GetLinkedLibs()}")  # type: ignore
+  print(f" GetLinkdefSuffix()           = {ROOT.gSystem.GetLinkdefSuffix()}")  # type: ignore
+  print(f" GetLibraries()               = {ROOT.gSystem.GetLibraries()}")  # type: ignore
+  print(f" GetMakeExe()                 = {ROOT.gSystem.GetMakeExe()}")  # type: ignore
+  print(f" GetMakeSharedLib()           = {ROOT.gSystem.GetMakeSharedLib()}")  # type: ignore
+
+
+def enableRootACLiCOpenMp():
+  '''Enables openMP support for ROOT macros compiled via ACLiC'''
+  # !Note! MacOS (requires libomp to be installed via MacPorts or Homebrew see testOpenMp.c)
+  ROOT.gSystem.SetFlagsOpt("-Xpreprocessor -fopenmp")  # compiler flags for optimized mode  # type: ignore
+  ROOT.gSystem.AddIncludePath("-I/opt/local/include/libomp")  # type: ignore
+  ROOT.gSystem.AddDynamicPath("/opt/local/lib/libomp")  # type: ignore
+  ROOT.gSystem.AddLinkedLibs("-L/opt/local/lib/libomp -lomp")  # type: ignore
+enableRootACLiCOpenMp()
+
+
 # C++ implementation of (complex conjugated) Wigner D function and spherical harmonics
 # also provides complexT typedef for std::complex<double>
 ROOT.gROOT.LoadMacro("./wignerD.C++")  # type: ignore
@@ -17,6 +48,10 @@ ROOT.gROOT.LoadMacro("./wignerD.C++")  # type: ignore
 
 if __name__ == "__main__":
   ROOT.gROOT.SetBatch(True)  # type: ignore
+
+  printRootACLiCSettings()
+  ROOT.testOpenMp()  # type: ignore
+  raise ValueError
 
   # see https://root.cern/doc/master/pyroot001__arrayInterface_8py.html
   # and https://root-forum.cern.ch/t/stl-vector-and-numpy-types-in-pyroot/54073/6
@@ -28,6 +63,6 @@ if __name__ == "__main__":
   theta = ROOT.std.vector["double"](vals)  # type: ignore
   phi   = ROOT.std.vector["double"](vals)  # type: ignore
   Phi   = ROOT.std.vector["double"](vals)  # type: ignore
-  fcnResults = ROOT.f_meas(1, 3, 2, theta, phi, Phi, 1.0)
+  fcnResults = ROOT.f_meas(1, 3, 2, theta, phi, Phi, 1.0)  # type: ignore
   arr = np.asarray(fcnResults)
   print(f"{type(arr)} {arr.dtype} {arr}")

--- a/testBasisFunc.py
+++ b/testBasisFunc.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+import functools
+import numpy as np
+
+import ROOT
+
+
+# always flush print() to reduce garbling of log files due to buffering
+print = functools.partial(print, flush = True)
+
+
+# C++ implementation of (complex conjugated) Wigner D function and spherical harmonics
+# also provides complexT typedef for std::complex<double>
+ROOT.gROOT.LoadMacro("./wignerD.C++")  # type: ignore
+
+
+if __name__ == "__main__":
+  ROOT.gROOT.SetBatch(True)  # type: ignore
+
+  # see https://root.cern/doc/master/pyroot001__arrayInterface_8py.html
+  # and https://root-forum.cern.ch/t/stl-vector-and-numpy-types-in-pyroot/54073/6
+  # and https://root-forum.cern.ch/t/cant-append-array-to-vector-in-pyroot-if-it-is-created-with-processline/43803/5
+  # cppyy does not work see https://github.com/root-project/root/issues/12635
+  # https://cppyy.readthedocs.io/en/latest/numba.html
+  # https://cppyy.readthedocs.io/en/latest/lowlevel.html#numpy-casts
+  vals = np.random.rand(10)
+  theta = ROOT.std.vector["double"](vals)  # type: ignore
+  phi   = ROOT.std.vector["double"](vals)  # type: ignore
+  Phi   = ROOT.std.vector["double"](vals)  # type: ignore
+  fcnResults = ROOT.f_meas(1, 3, 2, theta, phi, Phi, 1.0)
+  arr = np.asarray(fcnResults)
+  print(f"{type(arr)} {arr.dtype} {arr}")

--- a/testBasisFunc.py
+++ b/testBasisFunc.py
@@ -72,18 +72,18 @@ def enableRootACLiCOpenMp():
     # The only way to make it work is to copy/link `omp.h`` from the
     # gcc include dir here and turn the system include statement in
     # `wigner.C`` into the quoted form.
-enableRootACLiCOpenMp()
-
-
-# C++ implementation of (complex conjugated) Wigner D function and spherical harmonics
-# also provides complexT typedef for std::complex<double>
-ROOT.gROOT.LoadMacro("./wignerD.C++")  # type: ignore
 
 
 if __name__ == "__main__":
   ROOT.gROOT.SetBatch(True)  # type: ignore
 
+  enableRootACLiCOpenMp()
   printRootACLiCSettings()
+  # C++ implementation of (complex conjugated) Wigner D function and spherical harmonics
+  # also provides complexT typedef for std::complex<double>
+  ROOT.gROOT.LoadMacro("./wignerD.C++")  # type: ignore
+  print(f"Using {ROOT.getNmbOpenMpThreads()} OpenMP threads")  # type: ignore
+
   ROOT.testOpenMp()  # type: ignore
 
   # see https://root.cern/doc/master/pyroot001__arrayInterface_8py.html
@@ -105,7 +105,7 @@ if __name__ == "__main__":
   fcnResults2 = np.asarray(ROOT.f_phys_omp(1, 3, 2, theta, phi, Phi, 1.0))  # type: ignore
   stop = timeit.default_timer()
   time2 = stop -start
-  print(f"{ROOT.getNmbOpenMpThreads()} threads: {str(time2)} sec; speedup = {time1 / time2}; efficiency = {(time1 / time2) / ROOT.getNmbOpenMpThreads()}") # type: ignore
+  print(f"{ROOT.getNmbOpenMpThreads()} threads: {str(time2)} sec; speedup = {time1 / time2}; efficiency = {(time1 / time2) / ROOT.getNmbOpenMpThreads()}")  # type: ignore
   print(f"maximum difference: {max(fcnResults1 - fcnResults2):.16e}")
   # unset OpenMP variable
   if OMP_NUM_THREADS_save:

--- a/testBasisFunc.py
+++ b/testBasisFunc.py
@@ -33,11 +33,18 @@ def printRootACLiCSettings():
 
 def enableRootACLiCOpenMp():
   '''Enables openMP support for ROOT macros compiled via ACLiC'''
-  # !Note! MacOS (requires libomp to be installed via MacPorts or Homebrew see testOpenMp.c)
-  ROOT.gSystem.SetFlagsOpt("-Xpreprocessor -fopenmp")  # compiler flags for optimized mode  # type: ignore
-  ROOT.gSystem.AddIncludePath("-I/opt/local/include/libomp")  # type: ignore
-  ROOT.gSystem.AddDynamicPath("/opt/local/lib/libomp")  # type: ignore
-  ROOT.gSystem.AddLinkedLibs("-L/opt/local/lib/libomp -lomp")  # type: ignore
+  arch = ROOT.gSystem.GetBuildArch()  # type: ignore
+  if "macos" in arch.lower():
+    # !Note! MacOS (Apple does not ship libomp; needs to be installed via MacPorts or Homebrew see testOpenMp.c)
+    print(f"Enabling ACLiC compilation with OpenMP for MacOS")
+    ROOT.gSystem.SetFlagsOpt("-Xpreprocessor -fopenmp")  # compiler flags for optimized mode  # type: ignore
+    ROOT.gSystem.AddIncludePath("-I/opt/local/include/libomp")  # type: ignore
+    ROOT.gSystem.AddDynamicPath("/opt/local/lib/libomp")  # type: ignore
+    ROOT.gSystem.AddLinkedLibs("-L/opt/local/lib/libomp -lomp")  # type: ignore
+  elif "linux" in arch.lower():
+    print(f"Enabling ACLiC compilation with OpenMP for Linux")
+    ROOT.gSystem.SetFlagsOpt("-fopenmp")  # compiler flags for optimized mode  # type: ignore
+    ROOT.gSystem.AddLinkedLibs("-lomp")  # type: ignore
 enableRootACLiCOpenMp()
 
 
@@ -51,7 +58,6 @@ if __name__ == "__main__":
 
   printRootACLiCSettings()
   ROOT.testOpenMp()  # type: ignore
-  raise ValueError
 
   # see https://root.cern/doc/master/pyroot001__arrayInterface_8py.html
   # and https://root-forum.cern.ch/t/stl-vector-and-numpy-types-in-pyroot/54073/6

--- a/testMomentsPhotoProd.py
+++ b/testMomentsPhotoProd.py
@@ -327,8 +327,8 @@ def calcIntegralMatrix(
       for M in range(L + 1):
         if momentIndex == 2 and M == 0:
           continue  # H_2(L, 0) are always zero and would lead to a singular acceptance integral matrix
-        fMeasValues[(momentIndex, L, M)] = np.asarray(ROOT.f_meas_omp(momentIndex, L, M, thetaValues, phiValues, PhiValues, polarization))  # type: ignore
-        fPhysValues[(momentIndex, L, M)] = np.asarray(ROOT.f_phys_omp(momentIndex, L, M, thetaValues, phiValues, PhiValues, polarization))  # type: ignore
+        fMeasValues[(momentIndex, L, M)] = np.asarray(ROOT.f_meas(momentIndex, L, M, thetaValues, phiValues, PhiValues, polarization))  # type: ignore
+        fPhysValues[(momentIndex, L, M)] = np.asarray(ROOT.f_phys(momentIndex, L, M, thetaValues, phiValues, PhiValues, polarization))  # type: ignore
   # calculate integral-matrix elements; Eq. (178)
   I_acc: Dict[Tuple[int, ...], complex] = {}
   for indices_meas, f_meas in fMeasValues.items():

--- a/testMomentsPhotoProd.py
+++ b/testMomentsPhotoProd.py
@@ -712,6 +712,7 @@ if __name__ == "__main__":
     diff = trueVal - integralMatrixNumPy[indices]
     if not math.isclose(diff.real, 0, rel_tol = 0, abs_tol = 1e-14) or not math.isclose(diff.imag, 0, rel_tol = 0, abs_tol = 1e-14):
       print(f"    {indices}: {diff} = {trueVal} - {integralMatrixNumPy[indices]}")
+  print(f"Using OpenMP with {ROOT.getNmbOpenMpThreads()} threads")  # type: ignore
   ROOT.gBenchmark.Start("Time to calculate integral matrix (OpenMP)")  # type: ignore
   integralMatrixNativeLoop = calcIntegralMatrixOpenMp(dataAcceptedPs, nmbGenEvents = nmbMcEvents, polarization = polarization, maxL = getMaxSpin(PROD_AMPS))
   ROOT.gBenchmark.Stop("Time to calculate integral matrix (OpenMP)")  # type: ignore

--- a/testMomentsPhotoProd.py
+++ b/testMomentsPhotoProd.py
@@ -379,6 +379,11 @@ def calcIntegralMatrix(
     for indices_phys, f_phys in fPhysValues.items():
       I_acc2[indices_meas + indices_phys] = 8 * math.pi**2 / nmbGenEvents * np.dot(f_meas, f_phys)
   ROOT.gBenchmark.Stop("!!! integrals calculated using NumPy")  # type: ignore
+  # check result
+  for indices, trueVal in I_acc.items():
+    diff = trueVal - I_acc2[indices]
+    if not math.isclose(diff.real, 0, rel_tol = 0, abs_tol = 1e-14) or not math.isclose(diff.imag, 0, rel_tol = 0, abs_tol = 1e-14):
+      print(f"!!! {indices}: {diff} = {trueVal} - {I_acc2[indices]}")
   return I_acc
 
 
@@ -664,6 +669,7 @@ if __name__ == "__main__":
   ROOT.gBenchmark.Start("Time to calculate integral matrix")  # type: ignore
   integralMatrix = calcIntegralMatrix(dataAcceptedPs, nmbGenEvents = nmbMcEvents, polarization = polarization, maxL = getMaxSpin(PROD_AMPS))
   ROOT.gBenchmark.Stop("Time to calculate integral matrix")  # type: ignore
+  ROOT.gBenchmark.Stop("Total execution time")  # type: ignore
   _ = ctypes.c_float(0.0)  # dummy argument required by ROOT; sigh # type: ignore
   ROOT.gBenchmark.Summary(_, _)  # type: ignore
   raise ValueError

--- a/testMomentsPhotoProd.py
+++ b/testMomentsPhotoProd.py
@@ -585,8 +585,8 @@ if __name__ == "__main__":
   ROOT.gBenchmark.Start("Total execution time")  # type: ignore
 
   # get data
-  nmbEvents = 1000
-  nmbMcEvents = 100000
+  nmbEvents = 1000000
+  nmbMcEvents = 10000000
   polarization = 1.0
   # formulas for detection efficiency
   # x = cos(theta) in [-1, +1], y = phi in [-180, +180] deg, z = Phi in [-180, +180] deg

--- a/testOpenMp.c
+++ b/testOpenMp.c
@@ -1,0 +1,41 @@
+// on Linux:
+// > gcc -fopenmp -o testOpenMp{,.c}
+// > export OMP_NUM_THREADS=5
+// > ./testOpenMp
+//
+// on MacOS:
+// Apple does not ship OpenMP library -> install libomp e.g. via MacPorts or Homebrew
+// see https://open-box.readthedocs.io/en/latest/installation/openmp_macos.html
+// and https://stackoverflow.com/questions/43555410/enable-openmp-support-in-clang-in-mac-os-x-sierra-mojave
+// > sudo port install libomp
+// > /usr/bin/clang -Xpreprocessor -fopenmp -I/opt/local/include/libomp -L/opt/local/lib/libomp -lomp -o testOpenMp{,.c}
+// > export OMP_NUM_THREADS=5
+// > ./testOpenMp
+
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <omp.h>
+
+
+int
+main(
+	int   argc,
+	char* argv[]
+) {
+	// Fork a team of threads giving them their own copies of variables
+	int nmbThreads, threadId;
+	#pragma omp parallel private(nmbThreads, threadId)
+	{
+		// Obtain thread number
+		threadId = omp_get_thread_num();
+		printf("Hello World from thread = %d\n", threadId);
+		// Only master thread does this
+		if (threadId == 0) {
+			nmbThreads = omp_get_num_threads();
+			printf("Number of threads = %d\n", nmbThreads);
+		}
+	}
+	// All threads join master thread and disband
+}

--- a/wignerD.C
+++ b/wignerD.C
@@ -2,6 +2,7 @@
 #include <cmath>
 #include <complex>
 #include <iostream>
+#include <omp.h>
 
 #include "Math/SpecFuncMathMore.h"
 #include "TMath.h"
@@ -252,3 +253,24 @@ f_meas(
 // need typedef because templates are not allowed in TFormula expressions
 // see https://root-forum.cern.ch/t/trying-to-define-imaginary-error-function/50032/10
 typedef std::complex<double> complexT;
+
+
+// test OpenMP compilation and thread spawning
+void
+testOpenMp()
+{
+	// Fork a team of threads giving them their own copies of variables
+	int nmbThreads, threadId;
+	#pragma omp parallel private(nmbThreads, threadId)
+	{
+		// Obtain thread number
+		threadId = omp_get_thread_num();
+		std::cout << "Hello World from thread = " <<  threadId << std::endl;
+		// Only master thread does this
+		if (threadId == 0) {
+			nmbThreads = omp_get_num_threads();
+			std::cout << "Number of threads = " <<  nmbThreads << std::endl;
+		}
+	}
+	// All threads join master thread and disband
+}

--- a/wignerD.C
+++ b/wignerD.C
@@ -182,6 +182,27 @@ f_phys(
 }
 
 
+// vector version that calculates function value for each entry in the input vectors
+std::vector<std::complex<double>>
+f_phys(
+	const int                  momentIndex,  // 0, 1, or 2
+	const int                  L,
+	const int                  M,
+	const std::vector<double>& theta,  // [rad]
+	const std::vector<double>& phi,    // [rad]
+	const std::vector<double>& Phi,    // [rad]
+	const double               polarization
+) {
+	// assume that theta, phi, and Phi have the same length
+	const size_t nmbEvents = theta.size();
+	std::vector<std::complex<double>> fcnValues(nmbEvents);
+	for (size_t i = 0; i < theta.size(); ++i) {
+		fcnValues[i] = f_phys(momentIndex, L, M, theta[i], phi[i], Phi[i], polarization);
+	}
+	return fcnValues;
+}
+
+
 // basis functions for measured moments; Eq. (176)
 std::complex<double>
 f_meas(
@@ -204,6 +225,27 @@ f_meas(
 	default:
 		throw std::domain_error("f_meas() unknown moment index.");
 	}
+}
+
+
+// vector version that calculates function value for each entry in the input vectors
+std::vector<std::complex<double>>
+f_meas(
+	const int                  momentIndex,  // 0, 1, or 2
+	const int                  L,
+	const int                  M,
+	const std::vector<double>& theta,  // [rad]
+	const std::vector<double>& phi,    // [rad]
+	const std::vector<double>& Phi,    // [rad]
+	const double               polarization
+) {
+	// assume that theta, phi, and Phi have the same length
+	const size_t nmbEvents = theta.size();
+	std::vector<std::complex<double>> fcnValues(nmbEvents);
+	for (size_t i = 0; i < theta.size(); ++i) {
+		fcnValues[i] = f_meas(momentIndex, L, M, theta[i], phi[i], Phi[i], polarization);
+	}
+	return fcnValues;
 }
 
 


### PR DESCRIPTION
Going from RDataFrame to NumPy increased speed by about a factor 10. Performing the loop over events in C++ increased speed by nearly another factor of 10. Parallelizing the loop using OpenMP increased speed by about factor of 2.5 (all on 2021 MacBook Pro with M1 Max).