### PR TITLE
Update moment calculations for unpolarized case

### DIFF
--- a/MomentCalculator.py
+++ b/MomentCalculator.py
@@ -187,7 +187,7 @@ class AmplitudeSet:
     printMomentFormulas: bool = False,  # if set formulas for calculation of moments in terms of spin-density matrix elements are printed
   ) -> MomentResult:
     """Returns moments calculated from partial-wave amplitudes assuming rank-1 spin-density matrix; the moments H_2(L, 0) are omitted"""
-    momentIndices = MomentIndices(maxL)
+    momentIndices = MomentIndices(maxL, polarized = True)
     momentsFlatIndex = np.zeros((len(momentIndices), ), dtype = np.complex128)
     norm: float = 1.0
     for L in range(maxL + 1):
@@ -245,13 +245,13 @@ class QnMomentIndex:
 class MomentIndices:
   """Provides mapping between moment index schemes and iterators for moment indices"""
   maxL:                int  # maximum L quantum number of moments
-  photoProd:           bool = True  # switches between diffraction and photoproduction mode
+  polarized:           bool = False  # switches between unpolarized production and polarized photoproduction mode
   _QnIndexByFlatIndex: bd.bidict[int, QnMomentIndex] = field(init = False)  # bidirectional map for flat index <-> quantum-number index conversion
 
   def __post_init__(self) -> None:
     self._QnIndexByFlatIndex = bd.bidict()
     flatIndex = 0
-    for momentIndex in range(3 if self.photoProd else 1):
+    for momentIndex in range(3 if self.polarized else 1):
       for L in range(self.maxL + 1):
         for M in range(L + 1):
           if momentIndex == 2 and M == 0:
@@ -304,7 +304,7 @@ class DataSet:
   data:           ROOT.RDataFrame  # data from which to calculate moments
   phaseSpaceData: ROOT.RDataFrame | None  # (accepted) phase-space data; None corresponds to perfect acceptance
   nmbGenEvents:   int  # number of generated events
-  polarization:   float | None = None  # photon-beam polarization; 0 = read from tree
+  polarization:   float | None = None  # photon-beam polarization; 0.0 = read from tree
 
 
 @dataclass(frozen = True)  # immutable

--- a/MomentCalculator.py
+++ b/MomentCalculator.py
@@ -653,13 +653,14 @@ class MomentResult:
     else:
       raise TypeError(f"Invalid subscript type {type(flatIndex)}.")
 
+  @property
   def values(self) -> Generator[MomentValue, None, None]:
     """Generator that yields moment values"""
     for flatIndex in self.indices.flatIndices:
       yield self[flatIndex]
 
   def __str__(self) -> str:
-    result = (str(moment) for moment in self.values())
+    result = (str(moment) for moment in self.values)
     return "\n".join(result)
 
   def covariance(

--- a/MomentCalculator.py
+++ b/MomentCalculator.py
@@ -248,16 +248,19 @@ class MomentIndices:
   polarized:           bool = False  # switches between unpolarized production and polarized photoproduction mode
   _QnIndexByFlatIndex: bd.bidict[int, QnMomentIndex] = field(init = False)  # bidirectional map for flat index <-> quantum-number index conversion
 
-  def __post_init__(self) -> None:
+  def regenerateIndexMaps(self) -> None:
     self._QnIndexByFlatIndex = bd.bidict()
     flatIndex = 0
-    for momentIndex in range(3 if self.polarized else 1):
+    for momentIndex in range(self.momentIndexRange):
       for L in range(self.maxL + 1):
         for M in range(L + 1):
           if momentIndex == 2 and M == 0:
             continue  # H_2(L, 0) are always zero and would lead to a singular acceptance integral matrix
           self._QnIndexByFlatIndex[flatIndex] = QnMomentIndex(momentIndex, L, M)
           flatIndex += 1
+
+  def __post_init__(self) -> None:
+    self.regenerateIndexMaps()
 
   def __len__(self) -> int:
     """Returns total number of moments"""

--- a/MomentCalculator.py
+++ b/MomentCalculator.py
@@ -328,6 +328,13 @@ class AcceptanceIntegralMatrix:
   dataSet:     DataSet        # info on data samples
   _IFlatIndex: npt.NDArray[npt.Shape["Dim, Dim"], npt.Complex128] | None = None  # acceptance integral matrix with flat indices; first index is for measured moments, second index is for physical moments; must either be given or set be calling load() or calculate()
 
+  def __post_init__(self) -> None:
+    # set polarized moments case of `indices` according to info provided by `dataSet`
+    if self.dataSet.polarization is None:
+      self.indices.polarized = False
+    else:
+      self.indices.polarized = True
+
   # accessor that guarantees existence of optional field
   @property
   def matrix(self) -> npt.NDArray[npt.Shape["Dim, Dim"], npt.Complex128]:
@@ -812,6 +819,13 @@ class MomentCalculator:
   _integralMatrix:      AcceptanceIntegralMatrix | None = None  # if None no acceptance correction is performed; must either be given or calculated by calling calculateIntegralMatrix()
   _HMeas:               MomentResult | None = None  # measured moments; must either be given or calculated by calling calculateMoments()
   _HPhys:               MomentResult | None = None  # physical moments; must either be given or calculated by calling calculateMoments()
+
+  def __post_init__(self) -> None:
+    # set polarized moments case of `indices` according to info provided by `dataSet`
+    if self.dataSet.polarization is None:
+      self.indices.polarized = False
+    else:
+      self.indices.polarized = True
 
   # accessors that guarantee existence of optional fields
   @property

--- a/MomentCalculator.py
+++ b/MomentCalculator.py
@@ -419,16 +419,17 @@ class AcceptanceIntegralMatrix:
     beamPol: float | ROOT.std.vector["double"] | None = None
     if self.dataSet.polarization is None:
       # unpolarized case
-      raise NotImplementedError("Unpolarized case not implemented yet")
+      print("Calculating acceptance integral matrix for unpolarized production")
+      beamPol = 0.0  # for unpolarized production the basis functions are independent of beamPol; set value to zero
     elif self.dataSet.polarization == 0:
       # polarized case: read polarization value from tree
       assert "beamPol" in self.dataSet.phaseSpaceData.GetColumnNames(), "No 'beamPol' column found in phase-space data"
-      print("Reading beam polarization from 'beamPol' column when calculating the acceptance integral matrix")
+      print("Reading photon-beam polarization from 'beamPol' column when calculating the acceptance integral matrix")
       beamPol = ROOT.std.vector["double"](self.dataSet.phaseSpaceData.AsNumpy(columns = ["beamPol"])["beamPol"])
     else:
       # polarized case: use polarization value defined for data set
       beamPol = self.dataSet.polarization
-      print(f"Using beam polarization of {beamPol} when calculating the acceptance integral matrix")
+      print(f"Using photon-beam polarization of {beamPol} when calculating the acceptance integral matrix")
     # get event weights
     eventWeights: npt.NDArray[npt.Shape["nmbAccEvents"], npt.Float64] = np.empty(nmbAccEvents, dtype = np.float64)
     if "eventWeight" in self.dataSet.phaseSpaceData.GetColumnNames():
@@ -909,16 +910,17 @@ class MomentCalculator:
     beamPol: float | ROOT.std.vector["double"] | None = None
     if dataSet.polarization is None:
       # unpolarized case
-      raise NotImplementedError("Unpolarized case not implemented yet")
-    elif self.dataSet.polarization == 0:
+      print("Calculating moments for unpolarized production")
+      beamPol = 0.0  # for unpolarized production the basis functions are independent of beamPol; set value to zero
+    elif dataSet.polarization == 0:
       # polarized case: read polarization value from tree
       assert "beamPol" in dataSet.data.GetColumnNames(), "No 'beamPol' column found in data"
-      print("Reading beam polarization from 'beamPol' column when calculating the moments")
+      print("Reading photon-beam polarization from 'beamPol' column when calculating the moments")
       beamPol = ROOT.std.vector["double"](dataSet.data.AsNumpy(columns = ["beamPol"])["beamPol"])
     else:
       # polarized case: use polarization value defined for data set
       beamPol = dataSet.polarization
-      print(f"Using beam polarization of {beamPol} when calculating the moments")
+      print(f"Using photon-beam polarization of {beamPol} when calculating the moments")
     # get event weights
     eventWeights: npt.NDArray[npt.Shape["nmbEvents"], npt.Float64] = np.empty(nmbEvents, dtype = np.float64)
     if "eventWeight" in dataSet.data.GetColumnNames():

--- a/MomentCalculator.py
+++ b/MomentCalculator.py
@@ -407,15 +407,7 @@ class AcceptanceIntegralMatrix:
       print("Warning: no phase-space data; using perfect acceptance")
       self._IFlatIndex = np.eye(len(self.indices), dtype = np.complex128)
       return
-    # get phase-space data data as std::vectors
-    thetas = ROOT.std.vector["double"](self.dataSet.phaseSpaceData.AsNumpy(columns = ["theta"])["theta"])
-    phis   = ROOT.std.vector["double"](self.dataSet.phaseSpaceData.AsNumpy(columns = ["phi"  ])["phi"  ])
-    Phis   = ROOT.std.vector["double"](self.dataSet.phaseSpaceData.AsNumpy(columns = ["Phi"  ])["Phi"  ])
-    print(f"Phase-space data column: type = {type(thetas)}; length = {thetas.size()}; value type = {thetas.value_type}")
-    nmbAccEvents = thetas.size()
-    assert thetas.size() == phis.size() == Phis.size(), (
-      f"Not all std::vectors with input data have the correct size. Expected {nmbAccEvents} but got theta: {thetas.size()}, phi: {phis.size()}, and Phi: {Phis.size()}")
-    # get beam polarization
+    # get photon-beam polarization
     beamPol: float | ROOT.std.vector["double"] | None = None
     if self.dataSet.polarization is None:
       # unpolarized case
@@ -430,6 +422,15 @@ class AcceptanceIntegralMatrix:
       # polarized case: use polarization value defined for data set
       beamPol = self.dataSet.polarization
       print(f"Using photon-beam polarization of {beamPol} when calculating the acceptance integral matrix")
+    # get phase-space data data as std::vectors
+    thetas = ROOT.std.vector["double"](self.dataSet.phaseSpaceData.AsNumpy(columns = ["theta"])["theta"])
+    phis   = ROOT.std.vector["double"](self.dataSet.phaseSpaceData.AsNumpy(columns = ["phi"  ])["phi"  ])
+    Phis   = ROOT.std.vector["double"](self.dataSet.phaseSpaceData.AsNumpy(columns = ["Phi"  ])["Phi"  ]) if self.dataSet.polarization is not None else \
+             ROOT.std.vector["double"](np.zeros(len(thetas)))  # for unpolarized production the basis functions are independent of Phi; set values to zero
+    print(f"Phase-space data column: type = {type(thetas)}; length = {thetas.size()}; value type = {thetas.value_type}")
+    nmbAccEvents = thetas.size()
+    assert thetas.size() == phis.size() == Phis.size(), (
+      f"Not all std::vectors with input data have the correct size. Expected {nmbAccEvents} but got theta: {thetas.size()}, phi: {phis.size()}, and Phi: {Phis.size()}")
     # get event weights
     eventWeights: npt.NDArray[npt.Shape["nmbAccEvents"], npt.Float64] = np.empty(nmbAccEvents, dtype = np.float64)
     if "eventWeight" in self.dataSet.phaseSpaceData.GetColumnNames():
@@ -898,15 +899,7 @@ class MomentCalculator:
       dataSet = dataclasses.replace(self.dataSet, data = self.dataSet.phaseSpaceData)
     else:
       raise ValueError(f"Unknown data source '{dataSource}'")
-    # get input data as std::vectors
-    thetas = ROOT.std.vector["double"](dataSet.data.AsNumpy(columns = ["theta"])["theta"])
-    phis   = ROOT.std.vector["double"](dataSet.data.AsNumpy(columns = ["phi"  ])["phi"  ])
-    Phis   = ROOT.std.vector["double"](dataSet.data.AsNumpy(columns = ["Phi"  ])["Phi"  ])
-    print(f"Input data column: type = {type(thetas)}; length = {thetas.size()}; value type = {thetas.value_type}")
-    nmbEvents = thetas.size()
-    assert thetas.size() == phis.size() == Phis.size(), (
-      f"Not all std::vectors with input data have the correct size. Expected {nmbEvents} but got theta: {thetas.size()}, phi: {phis.size()}, and Phi: {Phis.size()}")
-    # get beam polarization
+    # get photon-beam polarization
     beamPol: float | ROOT.std.vector["double"] | None = None
     if dataSet.polarization is None:
       # unpolarized case
@@ -921,6 +914,15 @@ class MomentCalculator:
       # polarized case: use polarization value defined for data set
       beamPol = dataSet.polarization
       print(f"Using photon-beam polarization of {beamPol} when calculating the moments")
+    # get input data as std::vectors
+    thetas = ROOT.std.vector["double"](dataSet.data.AsNumpy(columns = ["theta"])["theta"])
+    phis   = ROOT.std.vector["double"](dataSet.data.AsNumpy(columns = ["phi"  ])["phi"  ])
+    Phis   = ROOT.std.vector["double"](dataSet.data.AsNumpy(columns = ["Phi"  ])["Phi"  ]) if dataSet.polarization is not None else \
+             ROOT.std.vector["double"](np.zeros(len(thetas)))  # for unpolarized production the basis functions are independent of Phi; set values to zero
+    print(f"Input data column: type = {type(thetas)}; length = {thetas.size()}; value type = {thetas.value_type}")
+    nmbEvents = thetas.size()
+    assert thetas.size() == phis.size() == Phis.size(), (
+      f"Not all std::vectors with input data have the correct size. Expected {nmbEvents} but got theta: {thetas.size()}, phi: {phis.size()}, and Phi: {Phis.size()}")
     # get event weights
     eventWeights: npt.NDArray[npt.Shape["nmbEvents"], npt.Float64] = np.empty(nmbEvents, dtype = np.float64)
     if "eventWeight" in dataSet.data.GetColumnNames():

--- a/MomentCalculator.py
+++ b/MomentCalculator.py
@@ -109,7 +109,7 @@ class AmplitudeSet:
     for reflIndex in reflIndices:
       for l in range(self.maxSpin + 1):
         for m in range(-l, l + 1):
-          yield self[QnWaveIndex(+1 if reflIndex == 0 else -1, l, m)]
+          yield self[QnWaveIndex(refl = (+1 if reflIndex == 0 else -1), l, m)]
 
   @property
   def maxSpin(self) -> int:
@@ -246,17 +246,17 @@ class MomentIndices:
   """Provides mapping between moment index schemes and iterators for moment indices"""
   maxL:                int  # maximum L quantum number of moments
   polarized:           bool = False  # switches between unpolarized production and polarized photoproduction mode
-  _QnIndexByFlatIndex: bd.bidict[int, QnMomentIndex] = field(init = False)  # bidirectional map for flat index <-> quantum-number index conversion
+  _qnIndexByFlatIndex: bd.bidict[int, QnMomentIndex] = field(init = False)  # bidirectional map for flat index <-> quantum-number index conversion
 
   def regenerateIndexMaps(self) -> None:
-    self._QnIndexByFlatIndex = bd.bidict()
+    self._qnIndexByFlatIndex = bd.bidict()
     flatIndex = 0
     for momentIndex in range(self.momentIndexRange):
       for L in range(self.maxL + 1):
         for M in range(L + 1):
           if momentIndex == 2 and M == 0:
             continue  # H_2(L, 0) are always zero and would lead to a singular acceptance integral matrix
-          self._QnIndexByFlatIndex[flatIndex] = QnMomentIndex(momentIndex, L, M)
+          self._qnIndexByFlatIndex[flatIndex] = QnMomentIndex(momentIndex, L, M)
           flatIndex += 1
 
   def __post_init__(self) -> None:
@@ -264,7 +264,7 @@ class MomentIndices:
 
   def __len__(self) -> int:
     """Returns total number of moments"""
-    return len(self._QnIndexByFlatIndex)
+    return len(self._qnIndexByFlatIndex)
 
   @overload
   def __getitem__(
@@ -284,9 +284,9 @@ class MomentIndices:
   ) -> QnMomentIndex | int:
     """Returns QnIndex that correspond to given flat index and vice versa"""
     if isinstance(subscript, int):
-      return self._QnIndexByFlatIndex[subscript]
+      return self._qnIndexByFlatIndex[subscript]
     elif isinstance(subscript, QnMomentIndex):
-      return self._QnIndexByFlatIndex.inverse[subscript]
+      return self._qnIndexByFlatIndex.inverse[subscript]
     else:
       raise TypeError(f"Invalid subscript type {type(subscript)}.")
 
@@ -302,7 +302,7 @@ class MomentIndices:
       yield flatIndex
 
   @property
-  def QnIndices(self) -> Generator[QnMomentIndex, None, None]:
+  def qnIndices(self) -> Generator[QnMomentIndex, None, None]:
     """Generates quantum-number indices of the form QnIndex(moment index, L, M)"""
     for flatIndex in range(len(self)):
       yield self[flatIndex]

--- a/MomentCalculator.py
+++ b/MomentCalculator.py
@@ -295,11 +295,13 @@ class MomentIndices:
     """Returns range of moment indices"""
     return 3 if self.polarized else 1
 
+  @property
   def flatIndices(self) -> Generator[int, None, None]:
     """Generates flat indices"""
     for flatIndex in range(len(self)):
       yield flatIndex
 
+  @property
   def QnIndices(self) -> Generator[QnMomentIndex, None, None]:
     """Generates quantum-number indices of the form QnIndex(moment index, L, M)"""
     for flatIndex in range(len(self)):
@@ -453,14 +455,14 @@ class AcceptanceIntegralMatrix:
     nmbMoments = len(self.indices)
     fMeas: npt.NDArray[npt.Shape["nmbMoments, nmbAccEvents"], npt.Complex128] = np.empty((nmbMoments, nmbAccEvents), dtype = np.complex128)
     fPhys: npt.NDArray[npt.Shape["nmbMoments, nmbAccEvents"], npt.Complex128] = np.empty((nmbMoments, nmbAccEvents), dtype = np.complex128)
-    for flatIndex in self.indices.flatIndices():
+    for flatIndex in self.indices.flatIndices:
       qnIndex = self.indices[flatIndex]
       fMeas[flatIndex] = np.asarray(ROOT.f_meas(qnIndex.momentIndex, qnIndex.L, qnIndex.M, thetas, phis, Phis, beamPol))
       fPhys[flatIndex] = np.asarray(ROOT.f_phys(qnIndex.momentIndex, qnIndex.L, qnIndex.M, thetas, phis, Phis, beamPol))
     # calculate integral-matrix elements; Eq. (178)
     self._IFlatIndex = np.empty((nmbMoments, nmbMoments), dtype = np.complex128)
-    for flatIndexMeas in self.indices.flatIndices():
-      for flatIndexPhys in self.indices.flatIndices():
+    for flatIndexMeas in self.indices.flatIndices:
+      for flatIndexPhys in self.indices.flatIndices:
         self._IFlatIndex[flatIndexMeas, flatIndexPhys] = ((8 * np.pi**2 / self.dataSet.nmbGenEvents)
           * np.dot(np.multiply(eventWeights, fMeas[flatIndexMeas]), fPhys[flatIndexPhys]))
     assert self.isValid(), f"Acceptance integral matrix does not exist or has wrong shape"
@@ -653,7 +655,7 @@ class MomentResult:
 
   def values(self) -> Generator[MomentValue, None, None]:
     """Generator that yields moment values"""
-    for flatIndex in self.indices.flatIndices():
+    for flatIndex in self.indices.flatIndices:
       yield self[flatIndex]
 
   def __str__(self) -> str:
@@ -952,7 +954,7 @@ class MomentCalculator:
       nmbBootstrapSamples = nmbBootstrapSamples,
       bootstrapSeed       = bootstrapSeed,
     )
-    for flatIndex in self.indices.flatIndices():
+    for flatIndex in self.indices.flatIndices:
       qnIndex = self.indices[flatIndex]
       fMeas[flatIndex] = np.asarray(ROOT.f_meas(qnIndex.momentIndex, qnIndex.L, qnIndex.M, thetas, phis, Phis, beamPol))  # Eq. (176)
       weightedSum = eventWeights.dot(fMeas[flatIndex])

--- a/MomentCalculator.py
+++ b/MomentCalculator.py
@@ -751,6 +751,18 @@ class MomentResult:
     """Returns whether bootstrap samples exist"""
     return self._bsSamplesFlatIndex.size > 0
 
+  def scaleBy(
+    self,
+    factor: float,
+  ) -> None:
+    """Scales moment values and uncertainties by given factor"""
+    self._valsFlatIndex    *= factor
+    self._covReReFlatIndex *= factor**2
+    self._covImImFlatIndex *= factor**2
+    self._covReImFlatIndex *= factor**2
+    if self.hasBootstrapSamples:
+      self._bsSamplesFlatIndex *= factor
+
   def save(
     self,
     pickleFileName: str,
@@ -824,6 +836,14 @@ class MomentResultsKinematicBinning:
   def __iter__(self) -> Iterator[MomentResult]:
     """Iterates over MomentResults in kinematic bins"""
     return iter(self.moments)
+
+  def scaleBy(
+    self,
+    factor: float,
+  ) -> None:
+    """Scales MomentResults by given factor"""
+    for moment in self:
+      moment.scaleBy(factor)
 
   def save(
     self,

--- a/MomentCalculator.py
+++ b/MomentCalculator.py
@@ -109,7 +109,7 @@ class AmplitudeSet:
     for reflIndex in reflIndices:
       for l in range(self.maxSpin + 1):
         for m in range(-l, l + 1):
-          yield self[QnWaveIndex(refl = (+1 if reflIndex == 0 else -1), l, m)]
+          yield self[QnWaveIndex(refl = (+1 if reflIndex == 0 else -1), l = l, m = m)]
 
   @property
   def maxSpin(self) -> int:

--- a/MomentCalculator.py
+++ b/MomentCalculator.py
@@ -287,6 +287,11 @@ class MomentIndices:
     else:
       raise TypeError(f"Invalid subscript type {type(subscript)}.")
 
+  @property
+  def momentIndexRange(self) -> int:
+    """Returns range of moment indices"""
+    return 3 if self.polarized else 1
+
   def flatIndices(self) -> Generator[int, None, None]:
     """Generates flat indices"""
     for flatIndex in range(len(self)):

--- a/MomentCalculator.py
+++ b/MomentCalculator.py
@@ -304,7 +304,7 @@ class DataSet:
   data:           ROOT.RDataFrame  # data from which to calculate moments
   phaseSpaceData: ROOT.RDataFrame | None  # (accepted) phase-space data; None corresponds to perfect acceptance
   nmbGenEvents:   int  # number of generated events
-  polarization:   float | None = None  # photon-beam polarization; None = read from tree
+  polarization:   float | None = None  # photon-beam polarization; 0 = read from tree
 
 
 @dataclass(frozen = True)  # immutable
@@ -411,12 +411,15 @@ class AcceptanceIntegralMatrix:
     # get beam polarization
     beamPol: float | ROOT.std.vector["double"] | None = None
     if self.dataSet.polarization is None:
-      # read polarization value from tree
+      # unpolarized case
+      raise NotImplementedError("Unpolarized case not implemented yet")
+    elif self.dataSet.polarization == 0:
+      # polarized case: read polarization value from tree
       assert "beamPol" in self.dataSet.phaseSpaceData.GetColumnNames(), "No 'beamPol' column found in phase-space data"
       print("Reading beam polarization from 'beamPol' column when calculating the acceptance integral matrix")
       beamPol = ROOT.std.vector["double"](self.dataSet.phaseSpaceData.AsNumpy(columns = ["beamPol"])["beamPol"])
     else:
-      # use polarization value defined for data set
+      # polarized case: use polarization value defined for data set
       beamPol = self.dataSet.polarization
       print(f"Using beam polarization of {beamPol} when calculating the acceptance integral matrix")
     # get event weights
@@ -891,12 +894,15 @@ class MomentCalculator:
     # get beam polarization
     beamPol: float | ROOT.std.vector["double"] | None = None
     if dataSet.polarization is None:
-      # read polarization value from tree
+      # unpolarized case
+      raise NotImplementedError("Unpolarized case not implemented yet")
+    elif self.dataSet.polarization == 0:
+      # polarized case: read polarization value from tree
       assert "beamPol" in dataSet.data.GetColumnNames(), "No 'beamPol' column found in data"
       print("Reading beam polarization from 'beamPol' column when calculating the moments")
       beamPol = ROOT.std.vector["double"](dataSet.data.AsNumpy(columns = ["beamPol"])["beamPol"])
     else:
-      # use polarization value defined for data set
+      # polarized case: use polarization value defined for data set
       beamPol = dataSet.polarization
       print(f"Using beam polarization of {beamPol} when calculating the moments")
     # get event weights

--- a/PlottingUtilities.py
+++ b/PlottingUtilities.py
@@ -952,6 +952,8 @@ def plotAngularDistr(
       if weightColName in self.dataFrame.GetColumnNames():
         cols += [weightColName]
       return cols
+    def hasPhiColumn(self) -> bool:
+      return "PhiDeg" in self.dataFrame.GetColumnNames()
   dataInfos = [
     DataInfo(dataSignalAcc, "signalAcc"),
     DataInfo(dataPsAcc,     "psAcc"),
@@ -970,11 +972,14 @@ def plotAngularDistr(
         ROOT.RDF.TH2DModel(f"{dataInfo.label}_2D", title2D, nmbBins2D, -1, +1, nmbBins2D, -180, +180),
         *dataInfo.useColumns(columns2D)
       ),
-      dataInfo.dataFrame.Histo3D(
-        ROOT.RDF.TH3DModel(f"{dataInfo.label}_3D", title3D, nmbBins3D, -1, +1, nmbBins3D, -180, +180, nmbBins3D, -180, +180),
-        *dataInfo.useColumns(columns3D)
-      ),
     ]
+    if dataInfo.hasPhiColumn():
+      hists += [
+        dataInfo.dataFrame.Histo3D(
+          ROOT.RDF.TH3DModel(f"{dataInfo.label}_3D", title3D, nmbBins3D, -1, +1, nmbBins3D, -180, +180, nmbBins3D, -180, +180),
+          *dataInfo.useColumns(columns3D)
+        ),
+      ]
   for hist in hists:
     canv = ROOT.TCanvas()
     hist.SetMinimum(0)

--- a/PlottingUtilities.py
+++ b/PlottingUtilities.py
@@ -13,12 +13,8 @@ import os
 from scipy import stats
 from typing import (
   Any,
-  Dict,
   Iterator,
-  List,
-  Optional,
   Sequence,
-  Tuple,
 )
 
 import ROOT
@@ -48,7 +44,7 @@ print = functools.partial(print, flush = True)
 @dataclass
 class MomentValueAndTruth(MomentValue):
   """Stores and provides access to single moment value and provides truth value"""
-  truth: Optional[complex] = None  # true moment value
+  truth: complex | None = None  # true moment value
 
   def truthRealPart(
     self,
@@ -68,7 +64,7 @@ class HistAxisBinning:
   nmbBins: int    # number of bins
   minVal:  float  # lower limit
   maxVal:  float  # upper limit
-  _var:    Optional[KinematicBinningVariable] = None  # optional info about bin variable
+  _var:    KinematicBinningVariable | None = None  # optional info about bin variable
 
   # make HistAxisBinning behave like a list of bin centers
   def __len__(self) -> int:
@@ -97,7 +93,7 @@ class HistAxisBinning:
     return self._var
 
   @property
-  def astuple(self) -> Tuple[int, float, float]:
+  def astuple(self) -> tuple[int, float, float]:
     """Returns tuple with binning info that can be directly used in ROOT.THX() constructor"""
     return (self.nmbBins, self.minVal, self.maxVal)
 
@@ -123,13 +119,13 @@ class HistAxisBinning:
   def binValueRange(
     self,
     binIndex: int,
-  ) -> Tuple[float, float]:
+  ) -> tuple[float, float]:
     """Returns value range for bin with given index"""
     binCenter = self[binIndex]
     return (binCenter - 0.5 * self.binWidth, binCenter + 0.5 * self.binWidth)
 
   @property
-  def binValueRanges(self) -> Tuple[Tuple[float, float], ...]:
+  def binValueRanges(self) -> tuple[tuple[float, float], ...]:
     """Returns value ranges for all bins"""
     return tuple((binCenter - 0.5 * self.binWidth, binCenter + 0.5 * self.binWidth) for binCenter in self)
 
@@ -155,9 +151,9 @@ def setupPlotStyle(rootlogonPath: str = "./rootlogon.C") -> None:
 def plotRealMatrix(
   matrix:      npt.NDArray[npt.Shape["*, *"], npt.Float64],  # matrix to plot
   pdfFileName: str,  # name of output file
-  axisTitles:  Tuple[str, str]                         = ("", ""),      # titles for x and y axes
-  plotTitle:   str                                     = "",            # title for plot
-  zRange:      Tuple[Optional[float], Optional[float]] = (None, None),  # range for z-axis
+  axisTitles:  tuple[str, str]                   = ("", ""),      # titles for x and y axes
+  plotTitle:   str                               = "",            # title for plot
+  zRange:      tuple[float | None, float | None] = (None, None),  # range for z-axis
   **kwargs:    Any,  # additional keyword arguments for plt.matshow()
 ) -> None:
   """Plots given matrix into PDF file with given name"""
@@ -176,10 +172,10 @@ def plotRealMatrix(
 def plotComplexMatrix(
   complexMatrix:     npt.NDArray[npt.Shape["*, *"], npt.Complex128],  # matrix to plot
   pdfFileNamePrefix: str,  # name prefix for output files
-  axisTitles:        Tuple[str, str] = ("", ""),  # titles for x and y axes
-  plotTitle:         str             = "",   # title for plot
-  zRangeAbs:         float           = 1.1,  # range for absolute value and for abs(real part)
-  zRangeImag:        float           = 0.075,  # range for abs(imag part)
+  axisTitles:        tuple[str, str] = ("", ""),  # titles for x and y axes
+  plotTitle:         str             = "",        # title for plot
+  zRangeAbs:         float           = 1.1,       # range for absolute value and for abs(real part)
+  zRangeImag:        float           = 0.075,     # range for abs(imag part)
   **kwargs:          Any,  # additional keyword arguments for plt.matshow()
 ) -> None:
   """Plots real and imaginary parts, absolute value and phase of given complex-valued matrix"""
@@ -195,12 +191,12 @@ def plotComplexMatrix(
 
 
 def drawTF3(
-  fcn:         ROOT.TF3,                # function to plot
-  binnings:    Tuple[HistAxisBinning, HistAxisBinning, HistAxisBinning],  # binnings of the 3 histogram axes: (x, y, z)
-  pdfFileName: str,                     # name of PDF file to write
-  histTitle:   str = "",                # histogram title
-  nmbPoints:   Optional[int]   = None,  # number of function points; used in numeric integration performed by GetRandom()
-  maxVal:      Optional[float] = None,  # maximum plot range
+  fcn:         ROOT.TF3,  # function to plot
+  binnings:    tuple[HistAxisBinning, HistAxisBinning, HistAxisBinning],  # binnings of the 3 histogram axes: (x, y, z)
+  pdfFileName: str,                  # name of PDF file to write
+  histTitle:   str          = "",    # histogram title
+  nmbPoints:   int | None   = None,  # number of function points; used in numeric integration performed by GetRandom()
+  maxVal:      float | None = None,  # maximum plot range
 ) -> None:
   """Draws given TF3 into histogram"""
   if nmbPoints:
@@ -235,13 +231,13 @@ def drawTF3(
 
 def plotMoments(
   HVals:             Sequence[MomentValueAndTruth],  # moment values extracted from data with (optional) true values
-  binning:           Optional[HistAxisBinning]           = None,  # if not None data are plotted as function of binning variable
-  normalizedMoments: bool                                = True,  # indicates whether moment values were normalized to H_0(0, 0)
-  momentLabel:       str                                 = QnMomentIndex.momentSymbol,  # label used in output file name #TODO does this default value actually work?
-  pdfFileNamePrefix: str                                 = "",  # name prefix for output files
-  histTitle:         str                                 = "",  # histogram title
-  plotLegend:        bool                                = True,
-  legendLabels:      Tuple[Optional[str], Optional[str]] = (None, None),  # labels for legend entries; None = use defaults
+  binning:           HistAxisBinning | None        = None,  # if not None data are plotted as function of binning variable
+  normalizedMoments: bool                          = True,  # indicates whether moment values were normalized to H_0(0, 0)
+  momentLabel:       str                           = QnMomentIndex.momentSymbol,  # label used in output file name #TODO does this default value actually work?
+  pdfFileNamePrefix: str                           = "",  # name prefix for output files
+  histTitle:         str                           = "",  # histogram title
+  plotLegend:        bool                          = True,
+  legendLabels:      tuple[str | None, str | None] = (None, None),  # labels for legend entries; None = use defaults
 ) -> None:
   """Plots moments extracted from data along categorical axis and overlays the corresponding true values if given"""
   histBinning = HistAxisBinning(len(HVals), 0, len(HVals)) if binning is None else binning
@@ -314,7 +310,7 @@ def plotMoments(
         *histBinning.astuple)
       # calculate residuals; NaN flags histogram bins, for which truth info is missing
       residuals = np.full(len(HVals) if binning is None else len(binning), np.nan)
-      indicesToMask: List[int] = []
+      indicesToMask: list[int] = []
       for index, HVal in enumerate(HVals):
         if (binning is not None) and (binning._var not in HVal.binCenters.keys()):
           continue
@@ -372,11 +368,11 @@ def plotMoments(
 
 def plotMomentsInBin(
   HData:             MomentResult,  # moments extracted from data
-  normalizedMoments: bool                                = True,  # indicates whether moment values were normalized to H_0(0, 0)
-  HTrue:             Optional[MomentResult]              = None,  # true moments
-  pdfFileNamePrefix: str                                 = "",    # name prefix for output files
-  plotLegend:        bool                                = True,
-  legendLabels:      Tuple[Optional[str], Optional[str]] = (None, None),  # labels for legend entries; None = use defaults
+  normalizedMoments: bool                          = True,  # indicates whether moment values were normalized to H_0(0, 0)
+  HTrue:             MomentResult | None           = None,  # true moments
+  pdfFileNamePrefix: str                           = "",    # name prefix for output files
+  plotLegend:        bool                          = True,
+  legendLabels:      tuple[str | None, str | None] = (None, None),  # labels for legend entries; None = use defaults
 ) -> None:
   """Plots H_i extracted from data for each i separately; the H_i with the same i are plotted as a categorical axis and overlaid with the corresponding true values if given"""
   # ensure that indices of HData and HTrue are compatible
@@ -413,12 +409,12 @@ def plotMoments1D(
   momentResults:     MomentResultsKinematicBinning,  # moments extracted from data
   qnIndex:           QnMomentIndex,    # defines specific moment
   binning:           HistAxisBinning,  # binning to use for plot
-  normalizedMoments: bool                                    = True,  # indicates whether moment values were normalized to H_0(0, 0)
-  momentResultsTrue: Optional[MomentResultsKinematicBinning] = None,  # true moments
-  pdfFileNamePrefix: str                                     = "",    # name prefix for output files
-  histTitle:         str                                     = "",    # histogram title
-  plotLegend:        bool                                    = True,
-  legendLabels:      Tuple[Optional[str], Optional[str]]     = (None, None),  # labels for legend entries; None = use defaults
+  normalizedMoments: bool                                 = True,  # indicates whether moment values were normalized to H_0(0, 0)
+  momentResultsTrue: MomentResultsKinematicBinning | None = None,  # true moments
+  pdfFileNamePrefix: str                                  = "",    # name prefix for output files
+  histTitle:         str                                  = "",    # histogram title
+  plotLegend:        bool                                 = True,
+  legendLabels:      tuple[str | None, str | None]        = (None, None),  # labels for legend entries; None = use defaults
 ) -> None:
   """Plots moment H_i(L, M) extracted from data as function of kinematical variable and overlays the corresponding true values if given"""
   # filter out specific moment given by qnIndex
@@ -442,10 +438,10 @@ def plotMoments1D(
 
 def plotMomentsBootstrapDistributions1D(
   HData:             MomentResult,  # moments extracted from data
-  HTrue:             Optional[MomentResult] = None,  # true moments
-  pdfFileNamePrefix: str                    = "",    # name prefix for output files
-  histTitle:         str                    = "",    # histogram title
-  nmbBins:           int                    = 100,   # number of bins for bootstrap histograms
+  HTrue:             MomentResult | None = None,  # true moments
+  pdfFileNamePrefix: str                 = "",    # name prefix for output files
+  histTitle:         str                 = "",    # histogram title
+  nmbBins:           int                 = 100,   # number of bins for bootstrap histograms
 ) -> None:
   """Plots 1D bootstrap distributions for H_0, H_1, and H_2 and overlays the true value and the estimate from uncertainty propagation"""
   assert not HTrue or HData.indices == HTrue.indices, f"Moment sets don't match. Data moments: {HData.indices} vs. true moments: {HTrue.indices}."
@@ -528,12 +524,12 @@ def plotMomentsBootstrapDistributions1D(
 
 
 def plotMomentPairBootstrapDistributions2D(
-  momentIndexPair:   Tuple[QnMomentIndex, QnMomentIndex],  # indices of moments to plot
+  momentIndexPair:   tuple[QnMomentIndex, QnMomentIndex],  # indices of moments to plot
   HData:             MomentResult,  # moments extracted from data
-  HTrue:             Optional[MomentResult] = None,  # true moments
-  pdfFileNamePrefix: str                    = "",    # name prefix for output files
-  histTitle:         str                    = "",    # histogram title
-  nmbBins:           int                    = 20,    # number of bins for bootstrap histograms
+  HTrue:             MomentResult | None = None,  # true moments
+  pdfFileNamePrefix: str                 = "",    # name prefix for output files
+  histTitle:         str                 = "",    # histogram title
+  nmbBins:           int                 = 20,    # number of bins for bootstrap histograms
 ) -> None:
   """Plots 2D bootstrap distributions of two moment values and overlays the true values and the estimates from uncertainty propagation"""
   HVals = (MomentValueAndTruth(*HData[momentIndexPair[0]], truth = HTrue[momentIndexPair[0]].val if HTrue else None),
@@ -627,10 +623,10 @@ def plotMomentPairBootstrapDistributions2D(
 
 def plotMomentsBootstrapDistributions2D(
   HData:             MomentResult,  # moments extracted from data
-  HTrue:             Optional[MomentResult] = None,  # true moments
-  pdfFileNamePrefix: str                    = "",    # name prefix for output files
-  histTitle:         str                    = "",    # histogram title
-  nmbBins:           int                    = 20,    # number of bins for bootstrap histograms
+  HTrue:             MomentResult | None = None,  # true moments
+  pdfFileNamePrefix: str                 = "",    # name prefix for output files
+  histTitle:         str                 = "",    # histogram title
+  nmbBins:           int                 = 20,    # number of bins for bootstrap histograms
 ) -> None:
   """Plots 2D bootstrap distributions of pairs of moment values that correspond to upper triangle of covariance matrix and overlays the true values and the estimates from uncertainty propagation"""
   momentIndexPairs = ((HData.indices[flatIndex0], HData.indices[flatIndex1])
@@ -651,9 +647,9 @@ def plotMomentsBootstrapDistributions2D(
 def plotMomentsCovMatrices(
   HData:             MomentResult,  # moments extracted from data
   pdfFileNamePrefix: str,  # name prefix for output files
-  axisTitles:        Tuple[str, str]                         = ("", ""),      # titles for x and y axes
-  plotTitle:         str                                     = "",            # title for plot
-  zRange:            Tuple[Optional[float], Optional[float]] = (None, None),  # range for z-axis
+  axisTitles:        tuple[str, str]                   = ("", ""),      # titles for x and y axes
+  plotTitle:         str                               = "",            # title for plot
+  zRange:            tuple[float | None, float | None] = (None, None),  # range for z-axis
 ):
   """Plots covariance matrices of moments and the difference w.r.t. the bootstrap estimates"""
   # get full composite covariance matrix from nominal estimate
@@ -715,9 +711,9 @@ def plotMomentsCovMatrices(
 def plotMomentsBootstrapDiff(
   HVals:             Sequence[MomentValueAndTruth],  # moment values extracted from data
   momentLabel:       str,  # label used in graph names and output file name
-  binning:           Optional[HistAxisBinning] = None,  # binning to use for plot; if None moment index is used as x-axis
-  pdfFileNamePrefix: str                       = "",    # name prefix for output files
-  graphTitle:        str                       = "",    # graph title
+  binning:           HistAxisBinning | None = None,  # binning to use for plot; if None moment index is used as x-axis
+  pdfFileNamePrefix: str                    = "",    # name prefix for output files
+  graphTitle:        str                    = "",    # graph title
 ) -> None:
   """Plots relative differences of estimates and their uncertainties for all given moments as function of moment index or binning variable"""
   assert all(HVal.hasBootstrapSamples for HVal in HVals), "Bootstrap samples must be present for all moments"
@@ -831,10 +827,10 @@ def plotMomentsBootstrapDiffInBin(
 def plotPullsForMoment(
   momentResults:     MomentResultsKinematicBinning,  # moments extracted from data
   qnIndex:           QnMomentIndex,  # defines specific moment
-  momentResultsTrue: Optional[MomentResultsKinematicBinning] = None,  # true moments
-  pdfFileNamePrefix: str                                     = "",    # name prefix for output files
-  histTitle:         str                                     = "",    # histogram title
-) -> Dict[bool, Tuple[Tuple[float, float], Tuple[float, float]]]:  # Gaussian mean and sigma with uncertainties, both for real and imaginary parts
+  momentResultsTrue: MomentResultsKinematicBinning | None = None,  # true moments
+  pdfFileNamePrefix: str                                  = "",    # name prefix for output files
+  histTitle:         str                                  = "",    # histogram title
+) -> dict[bool, tuple[tuple[float, float], tuple[float, float]]]:  # Gaussian mean and sigma with uncertainties, both for real and imaginary parts
   """Plots pulls of moment with given qnIndex estimated from moment values in kinematic bins"""
   # filter out specific moment given by qnIndex
   HVals = tuple(
@@ -844,7 +840,7 @@ def plotPullsForMoment(
     ) for binIndex, HPhys in enumerate(momentResults)
   )
   histStack = ROOT.THStack(f"{pdfFileNamePrefix}pulls_{qnIndex.label}", f"{histTitle};""(#it{#hat{H}} - #it{H}_{true}) / #it{#hat{#sigma}};Count")
-  gaussPars: Dict[bool, Tuple[Tuple[float, float], Tuple[float, float]]] = {}  # Gaussian mean and sigma with uncertainties, both for real and imaginary parts
+  gaussPars: dict[bool, tuple[tuple[float, float], tuple[float, float]]] = {}  # Gaussian mean and sigma with uncertainties, both for real and imaginary parts
   for realPart in (False, True):
     # loop over kinematic bins and fill histogram with pulls
     histPull = ROOT.TH1D(f"{histStack.GetName()}_{'Re' if realPart else 'Im'}", "Real Part" if realPart else "Imag Part", 25, -5, +5)
@@ -885,7 +881,7 @@ def plotPullsForMoment(
 
 
 def plotPullParameters(
-  pullParameters:    Dict[QnMomentIndex, Dict[bool, Tuple[Tuple[float, float], Tuple[float, float]]]],  # {index : {isReal : ((mean val, mean err), (sigma val, sigma err))}}
+  pullParameters:    dict[QnMomentIndex, dict[bool, tuple[tuple[float, float], tuple[float, float]]]],  # {index : {isReal : ((mean val, mean err), (sigma val, sigma err))}}
   pdfFileNamePrefix: str = "",  # name prefix for output files
   histTitle:         str = "",  # histogram title
 ) -> None:
@@ -933,10 +929,10 @@ def plotAngularDistr(
   dataPsAcc:         ROOT.RDataFrame,  # accepted phase-space data
   dataPsGen:         ROOT.RDataFrame,  # generated phase-space data
   dataSignalAcc:     ROOT.RDataFrame,  # accepted signal data
-  dataSignalGen:     Optional[ROOT.RDataFrame] = None,  # generated signal data
-  pdfFileNamePrefix: str                       = "",    # name prefix for output files
-  nmbBins3D:         int                       = 15,    # number of bins for 3D histograms
-  nmbBins2D:         int                       = 40,    # number of bins for 2D histograms
+  dataSignalGen:     ROOT.RDataFrame | None = None,  # generated signal data
+  pdfFileNamePrefix: str                    = "",    # name prefix for output files
+  nmbBins3D:         int                    = 15,    # number of bins for 3D histograms
+  nmbBins2D:         int                    = 40,    # number of bins for 2D histograms
 ):
   """Plot 2D and 3D angular distributions of signal and phase-space data"""
   @dataclass
@@ -947,7 +943,7 @@ def plotAngularDistr(
       self,
       columns: Sequence[str],
       weightColName: str = "eventWeight",
-    ) -> List[str]:
+    ) -> list[str]:
       cols = list(columns)
       if weightColName in self.dataFrame.GetColumnNames():
         cols += [weightColName]

--- a/PlottingUtilities.py
+++ b/PlottingUtilities.py
@@ -380,7 +380,7 @@ def plotMomentsInBin(
   """Plots H_0, H_1, and H_2 extracted from data along categorical axis and overlays the corresponding true values if given"""
   assert not HTrue or HData.indices == HTrue.indices, f"Moment sets don't match. Data moments: {HData.indices} vs. true moments: {HTrue.indices}."
   # generate separate plots for each moment index
-  for momentIndex in range(3):
+  for momentIndex in range(HData.indices.momentIndexRange):
     HVals = tuple(
       MomentValueAndTruth(
         *HData[qnIndex],
@@ -800,7 +800,7 @@ def plotMomentsBootstrapDiffInBin(
   graphTitle:        str = "",      # graph title
 ) -> None:
   """Plots relative differences of estimates and their uncertainties for all moments"""
-  for momentIndex in range(3):
+  for momentIndex in range(HData.indices.momentIndexRange):
     # get moments with index momentIndex
     HVals = tuple(
       MomentValueAndTruth(
@@ -880,7 +880,7 @@ def plotPullParameters(
 ) -> None:
   """Plots Gaussian means and sigmas of pull distributions for each moment"""
   # generate separate plots for each moment index
-  for momentIndex in range(3):
+  for momentIndex in range(3):  #TODO pass number of moment indices to function
     # get pull parameters for moment with given momentIndex
     pullPars = {qnIndex : pars for qnIndex, pars in pullParameters.items() if qnIndex.momentIndex == momentIndex}
     # create a histograms with the moments as the categorical axis and the Gaussian parameters as the y-axis

--- a/PlottingUtilities.py
+++ b/PlottingUtilities.py
@@ -392,7 +392,7 @@ def plotMomentsInBin(
       MomentValueAndTruth(
         *HData[qnIndex],
         truth = HTrue[qnIndex].val if HTrue else None
-      ) for qnIndex in HData.indices.QnIndices() if qnIndex.momentIndex == momentIndex
+      ) for qnIndex in HData.indices.QnIndices if qnIndex.momentIndex == momentIndex
     )
     plotMoments(
       HVals             = HVals,
@@ -446,7 +446,7 @@ def plotMomentsBootstrapDistributions1D(
   """Plots 1D bootstrap distributions for H_0, H_1, and H_2 and overlays the true value and the estimate from uncertainty propagation"""
   assert not HTrue or HData.indices == HTrue.indices, f"Moment sets don't match. Data moments: {HData.indices} vs. true moments: {HTrue.indices}."
   # generate separate plots for each moment index
-  for qnIndex in HData.indices.QnIndices():
+  for qnIndex in HData.indices.QnIndices:
     HVal = MomentValueAndTruth(
       *HData[qnIndex],
       truth = HTrue[qnIndex].val if HTrue else None
@@ -630,8 +630,8 @@ def plotMomentsBootstrapDistributions2D(
 ) -> None:
   """Plots 2D bootstrap distributions of pairs of moment values that correspond to upper triangle of covariance matrix and overlays the true values and the estimates from uncertainty propagation"""
   momentIndexPairs = ((HData.indices[flatIndex0], HData.indices[flatIndex1])
-                      for flatIndex0 in HData.indices.flatIndices()
-                      for flatIndex1 in HData.indices.flatIndices()
+                      for flatIndex0 in HData.indices.flatIndices
+                      for flatIndex1 in HData.indices.flatIndices
                       if flatIndex0 < flatIndex1)
   for momentIndexPair in momentIndexPairs:
     plotMomentPairBootstrapDistributions2D(
@@ -669,8 +669,8 @@ def plotMomentsCovMatrices(
       # of the covariance matrix including the diagonal
       # !Note! the ReIm matrix is _not_ symmetric, so we need all indices
       momentIndexPairs = ((flatIndex0, flatIndex1)
-                          for flatIndex0 in HData.indices.flatIndices()
-                          for flatIndex1 in HData.indices.flatIndices()
+                          for flatIndex0 in HData.indices.flatIndices
+                          for flatIndex1 in HData.indices.flatIndices
                           if (realParts[0] != realParts[1]) or (flatIndex0 <= flatIndex1))
       for momentIndexPair in momentIndexPairs:
         # covariance = off-diagonal element of the 2 x 2 covariance matrix returned by np.cov():
@@ -813,7 +813,7 @@ def plotMomentsBootstrapDiffInBin(
       MomentValueAndTruth(
         *HData[qnIndex],
         truth = None,
-      ) for qnIndex in HData.indices.QnIndices() if qnIndex.momentIndex == momentIndex
+      ) for qnIndex in HData.indices.QnIndices if qnIndex.momentIndex == momentIndex
     )
     plotMomentsBootstrapDiff(
       HVals             = HVals,

--- a/PlottingUtilities.py
+++ b/PlottingUtilities.py
@@ -442,6 +442,7 @@ def plotMomentsBootstrapDistributions1D(
   pdfFileNamePrefix: str                 = "",    # name prefix for output files
   histTitle:         str                 = "",    # histogram title
   nmbBins:           int                 = 100,   # number of bins for bootstrap histograms
+  HTrueLabel:        str                 = "True value",  # label for true value in legend
 ) -> None:
   """Plots 1D bootstrap distributions for H_0, H_1, and H_2 and overlays the true value and the estimate from uncertainty propagation"""
   assert not HTrue or HData.indices == HTrue.indices, f"Moment sets don't match. Data moments: {HData.indices} vs. true moments: {HTrue.indices}."
@@ -518,7 +519,7 @@ def plotMomentsBootstrapDistributions1D(
       entry.SetLineColor(ROOT.kGreen + 2)
       legend.AddEntry(gaussian, "Nominal estimate Gaussian", "LP")
       if HVal.truth is not None:
-        legend.AddEntry(lineTrue, "True value", "L")
+        legend.AddEntry(lineTrue, HTrueLabel, "L")
       legend.Draw()
       canv.SaveAs(f"{histBs.GetName()}.pdf")
 
@@ -530,6 +531,7 @@ def plotMomentPairBootstrapDistributions2D(
   pdfFileNamePrefix: str                 = "",    # name prefix for output files
   histTitle:         str                 = "",    # histogram title
   nmbBins:           int                 = 20,    # number of bins for bootstrap histograms
+  HTrueLabel:        str                 = "True value",  # label for true value in legend
 ) -> None:
   """Plots 2D bootstrap distributions of two moment values and overlays the true values and the estimates from uncertainty propagation"""
   HVals = (MomentValueAndTruth(*HData[momentIndexPair[0]], truth = HTrue[momentIndexPair[0]].val if HTrue else None),
@@ -616,7 +618,7 @@ def plotMomentPairBootstrapDistributions2D(
     entry = legend.AddEntry(markerEst, "Nominal estimate", "LP")
     entry.SetLineColor(ROOT.kGreen + 2)
     if plotTruth:
-      entry = legend.AddEntry(markerTruth, "True value", "P")
+      entry = legend.AddEntry(markerTruth, HTrueLabel, "P")
     legend.Draw()
     canv.SaveAs(f"{histBs.GetName()}.pdf")
 
@@ -627,6 +629,7 @@ def plotMomentsBootstrapDistributions2D(
   pdfFileNamePrefix: str                 = "",    # name prefix for output files
   histTitle:         str                 = "",    # histogram title
   nmbBins:           int                 = 20,    # number of bins for bootstrap histograms
+  HTrueLabel:        str                 = "True value",  # label for true value in legend
 ) -> None:
   """Plots 2D bootstrap distributions of pairs of moment values that correspond to upper triangle of covariance matrix and overlays the true values and the estimates from uncertainty propagation"""
   momentIndexPairs = ((HData.indices[flatIndex0], HData.indices[flatIndex1])
@@ -641,6 +644,7 @@ def plotMomentsBootstrapDistributions2D(
       pdfFileNamePrefix = pdfFileNamePrefix,
       histTitle         = histTitle,
       nmbBins           = nmbBins,
+      HTrueLabel        = HTrueLabel,
     )
 
 

--- a/PlottingUtilities.py
+++ b/PlottingUtilities.py
@@ -392,7 +392,7 @@ def plotMomentsInBin(
       MomentValueAndTruth(
         *HData[qnIndex],
         truth = HTrue[qnIndex].val if HTrue else None
-      ) for qnIndex in HData.indices.QnIndices if qnIndex.momentIndex == momentIndex
+      ) for qnIndex in HData.indices.qnIndices if qnIndex.momentIndex == momentIndex
     )
     plotMoments(
       HVals             = HVals,
@@ -446,7 +446,7 @@ def plotMomentsBootstrapDistributions1D(
   """Plots 1D bootstrap distributions for H_0, H_1, and H_2 and overlays the true value and the estimate from uncertainty propagation"""
   assert not HTrue or HData.indices == HTrue.indices, f"Moment sets don't match. Data moments: {HData.indices} vs. true moments: {HTrue.indices}."
   # generate separate plots for each moment index
-  for qnIndex in HData.indices.QnIndices:
+  for qnIndex in HData.indices.qnIndices:
     HVal = MomentValueAndTruth(
       *HData[qnIndex],
       truth = HTrue[qnIndex].val if HTrue else None
@@ -813,7 +813,7 @@ def plotMomentsBootstrapDiffInBin(
       MomentValueAndTruth(
         *HData[qnIndex],
         truth = None,
-      ) for qnIndex in HData.indices.QnIndices if qnIndex.momentIndex == momentIndex
+      ) for qnIndex in HData.indices.qnIndices if qnIndex.momentIndex == momentIndex
     )
     plotMomentsBootstrapDiff(
       HVals             = HVals,

--- a/PlottingUtilities.py
+++ b/PlottingUtilities.py
@@ -387,8 +387,15 @@ def plotMomentsInBin(
         truth = HTrue[qnIndex].val if HTrue else None
       ) for qnIndex in HData.indices.QnIndices() if qnIndex.momentIndex == momentIndex
     )
-    plotMoments(HVals, normalizedMoments = normalizedMoments, momentLabel = f"{QnMomentIndex.momentSymbol}{momentIndex}",
-                pdfFileNamePrefix = pdfFileNamePrefix, plotLegend = plotLegend, legendLabels = legendLabels)
+    plotMoments(
+      HVals             = HVals,
+      binning           = None,
+      normalizedMoments = normalizedMoments,
+      momentLabel       = f"{QnMomentIndex.momentSymbol}{momentIndex}",
+      pdfFileNamePrefix = pdfFileNamePrefix,
+      plotLegend        = plotLegend,
+      legendLabels      = legendLabels,
+    )
 
 
 def plotMoments1D(
@@ -410,8 +417,16 @@ def plotMoments1D(
       truth = None if momentResultsTrue is None else momentResultsTrue[binIndex][qnIndex].val,
     ) for binIndex, HPhys in enumerate(momentResults)
   )
-  plotMoments(HVals, binning, normalizedMoments, momentLabel = qnIndex.label, pdfFileNamePrefix = f"{pdfFileNamePrefix}{binning.var.name}_",
-              histTitle = histTitle, plotLegend = plotLegend, legendLabels = legendLabels)
+  plotMoments(
+    HVals             = HVals,
+    binning           = binning,
+    normalizedMoments = normalizedMoments,
+    momentLabel       = qnIndex.label,
+    pdfFileNamePrefix = f"{pdfFileNamePrefix}{binning.var.name}_",
+    histTitle         = histTitle,
+    plotLegend        = plotLegend,
+    legendLabels      = legendLabels,
+  )
 
 
 def plotMomentsBootstrapDistributions1D(
@@ -612,7 +627,14 @@ def plotMomentsBootstrapDistributions2D(
                       for flatIndex1 in HData.indices.flatIndices()
                       if flatIndex0 < flatIndex1)
   for momentIndexPair in momentIndexPairs:
-    plotMomentPairBootstrapDistributions2D(momentIndexPair, HData, HTrue, pdfFileNamePrefix, histTitle, nmbBins)
+    plotMomentPairBootstrapDistributions2D(
+      momentIndexPair   = momentIndexPair,
+      HData             = HData,
+      HTrue             = HTrue,
+      pdfFileNamePrefix = pdfFileNamePrefix,
+      histTitle         = histTitle,
+      nmbBins           = nmbBins,
+    )
 
 
 def plotMomentsCovMatrices(
@@ -763,7 +785,13 @@ def plotMomentsBootstrapDiff1D(
       truth = None,
     ) for HPhys in momentResults
   )
-  plotMomentsBootstrapDiff(HVals, momentLabel = qnIndex.label, binning = binning, pdfFileNamePrefix = f"{pdfFileNamePrefix}{binning.var.name}_", graphTitle = graphTitle)
+  plotMomentsBootstrapDiff(
+    HVals             = HVals,
+    momentLabel       = qnIndex.label,
+    binning           = binning,
+    pdfFileNamePrefix = f"{pdfFileNamePrefix}{binning.var.name}_",
+    graphTitle        = graphTitle,
+  )
 
 
 def plotMomentsBootstrapDiffInBin(
@@ -780,8 +808,13 @@ def plotMomentsBootstrapDiffInBin(
         truth = None,
       ) for qnIndex in HData.indices.QnIndices() if qnIndex.momentIndex == momentIndex
     )
-    plotMomentsBootstrapDiff(HVals, momentLabel = f"{QnMomentIndex.momentSymbol}{momentIndex}",
-                             pdfFileNamePrefix = pdfFileNamePrefix, graphTitle = graphTitle)
+    plotMomentsBootstrapDiff(
+      HVals             = HVals,
+      momentLabel       = f"{QnMomentIndex.momentSymbol}{momentIndex}",
+      binning           = None,
+      pdfFileNamePrefix = pdfFileNamePrefix,
+      graphTitle        = graphTitle,
+    )
 
 
 def plotPullsForMoment(

--- a/dataPhotoProdPiPiUnpol/makeMomentsInputTree.py
+++ b/dataPhotoProdPiPiUnpol/makeMomentsInputTree.py
@@ -72,5 +72,4 @@ if __name__ == "__main__":
       .Define("theta",       "std::acos(cosTheta)") \
       .Define("phi",         f"FSMath::helphi({lvPim}, {lvPip}, {lvRecoil}, {lvBeam})") \
       .Define("phiDeg",      "phi * TMath::RadToDeg()") \
-      .Define("eventWeight", "Weight") \
-      .Snapshot(outputTreeName, "acc_phase_space_flat.root", ("mass", "cosTheta", "theta", "phi", "phiDeg", "eventWeight"))
+      .Snapshot(outputTreeName, "acc_phase_space_flat.root", ("mass", "cosTheta", "theta", "phi", "phiDeg"))

--- a/dataPhotoProdPiPiUnpol/makeMomentsInputTree.py
+++ b/dataPhotoProdPiPiUnpol/makeMomentsInputTree.py
@@ -26,7 +26,8 @@ if __name__ == "__main__":
 
   dataSigRegionFileName = "./amptools_tree_data_tbin1_ebin4.root"
   dataBkgRegionFileName = "./amptools_tree_bkgnd_tbin1_ebin4.root"
-  mcDataFileName        = "./amptools_tree_accepted_tbin1_ebin4.root"
+  phaseSpaceAccFileName = "./amptools_tree_accepted_tbin1_ebin4.root"
+  phaseSpaceGenFileName = "./amptools_tree_thrown_tbin1_ebin4.root"
   treeName              = "kin"
   outputTreeName        = "PiPi"
 
@@ -61,15 +62,16 @@ if __name__ == "__main__":
       .Snapshot(outputTreeName, "data_flat.root", ("mass", "cosTheta", "theta", "phi", "phiDeg", "eventWeight"))
   #TODO investigate why FSMath::helphi(lvA, lvB, lvRecoil, lvBeam) yields value that differs by 180 deg from helphideg_Alex(lvA, lvB, lvRecoil, lvBeam)
 
-  # convert MC data
-  lvBeam   = "Px_Beam,          Py_Beam,          Pz_Beam,          E_Beam"
-  lvRecoil = "Px_FinalState[0], Py_FinalState[0], Pz_FinalState[0], E_FinalState[0]"
-  lvPip    = "Px_FinalState[1], Py_FinalState[1], Pz_FinalState[1], E_FinalState[1]"  #TODO not clear whether correct index is 1 or 2
-  lvPim    = "Px_FinalState[2], Py_FinalState[2], Pz_FinalState[2], E_FinalState[2]"  #TODO not clear whether correct index is 1 or 2
-  ROOT.RDataFrame(treeName, mcDataFileName) \
-      .Define("mass",        f"massPair({lvPip}, {lvPim})") \
-      .Define("cosTheta",    f"FSMath::helcostheta({lvPip}, {lvPim}, {lvRecoil})") \
-      .Define("theta",       "std::acos(cosTheta)") \
-      .Define("phi",         f"FSMath::helphi({lvPim}, {lvPip}, {lvRecoil}, {lvBeam})") \
-      .Define("phiDeg",      "phi * TMath::RadToDeg()") \
-      .Snapshot(outputTreeName, "acc_phase_space_flat.root", ("mass", "cosTheta", "theta", "phi", "phiDeg"))
+  for inFileName, outFileName in [(phaseSpaceAccFileName, "phaseSpace_acc_flat.root"), (phaseSpaceGenFileName, "phaseSpace_gen_flat.root")]:
+    # convert MC data
+    lvBeam   = "Px_Beam,          Py_Beam,          Pz_Beam,          E_Beam"
+    lvRecoil = "Px_FinalState[0], Py_FinalState[0], Pz_FinalState[0], E_FinalState[0]"
+    lvPip    = "Px_FinalState[1], Py_FinalState[1], Pz_FinalState[1], E_FinalState[1]"  #TODO not clear whether correct index is 1 or 2
+    lvPim    = "Px_FinalState[2], Py_FinalState[2], Pz_FinalState[2], E_FinalState[2]"  #TODO not clear whether correct index is 1 or 2
+    ROOT.RDataFrame(treeName, inFileName) \
+        .Define("mass",        f"massPair({lvPip}, {lvPim})") \
+        .Define("cosTheta",    f"FSMath::helcostheta({lvPip}, {lvPim}, {lvRecoil})") \
+        .Define("theta",       "std::acos(cosTheta)") \
+        .Define("phi",         f"FSMath::helphi({lvPim}, {lvPip}, {lvRecoil}, {lvBeam})") \
+        .Define("phiDeg",      "phi * TMath::RadToDeg()") \
+        .Snapshot(outputTreeName, outFileName, ("mass", "cosTheta", "theta", "phi", "phiDeg"))

--- a/momentsPhotoProdEtaPi0.py
+++ b/momentsPhotoProdEtaPi0.py
@@ -219,13 +219,33 @@ if __name__ == "__main__":
           phaseSpaceData = dataPsAccInBin,
           nmbGenEvents   = nmbPsGenEvents[-1],
         )
-        momentsInBins.append(MomentCalculator(momentIndices, dataSet, integralFileBaseName = f"{outFileDirName}/integralMatrix", binCenters = {binVarMass : massBinCenter}))
+        momentsInBins.append(
+          MomentCalculator(
+            indices              = momentIndices,
+            dataSet              = dataSet,
+            binCenters           = {binVarMass : massBinCenter},
+            integralFileBaseName = f"{outFileDirName}/integralMatrix",
+          )
+        )
         # setup moment calculator to hold moment values from PWA result
-        momentsInBinsPwa.append(MomentCalculator(momentIndices, dataSet, binCenters = {binVarMass : massBinCenter}, _HPhys = HPwa))
+        momentsInBinsPwa.append(
+          MomentCalculator(
+            indices    = momentIndices,
+            dataSet    = dataSet,
+            binCenters = {binVarMass : massBinCenter},
+            _HPhys     = HPwa,
+          )
+        )
 
         # plot angular distributions for mass bin
         if plotAngularDistributions:
-          plotAngularDistr(dataPsAccInBin, dataPsGenInBin, dataInBin, dataSignalGen = None, pdfFileNamePrefix = f"{outFileDirName}/angDistr_{binLabel(momentsInBins[-1])}_")
+          plotAngularDistr(
+            dataPsAcc         = dataPsAccInBin,
+            dataPsGen         = dataPsGenInBin,
+            dataSignalAcc     = dataInBin,
+            dataSignalGen     = None,
+            pdfFileNamePrefix = f"{outFileDirName}/angDistr_{binLabel(momentsInBins[-1])}_",
+          )
     moments    = MomentCalculatorsKinematicBinning(momentsInBins)
     momentsPwa = MomentCalculatorsKinematicBinning(momentsInBinsPwa)
 
@@ -240,13 +260,23 @@ if __name__ == "__main__":
       if plotAccIntegralMatrices:
         for momentResultInBin in moments:
           label = binLabel(momentResultInBin)
-          plotComplexMatrix(momentResultInBin.integralMatrix.matrixNormalized, pdfFileNamePrefix = f"{outFileDirName}/accMatrix_{label}_",
-                            axisTitles = ("Physical Moment Index", "Measured Moment Index"), plotTitle = f"{label}: "r"$\mathrm{\mathbf{I}}_\text{acc}$, ",
-                            zRangeAbs = 1.5, zRangeImag = 0.25)
-          plotComplexMatrix(momentResultInBin.integralMatrix.inverse,          pdfFileNamePrefix = f"{outFileDirName}/accMatrixInv_{label}_",
-                            axisTitles = ("Measured Moment Index", "Physical Moment Index"), plotTitle = f"{label}: "r"$\mathrm{\mathbf{I}}_\text{acc}^{-1}$, ",
-                            zRangeAbs = 115, zRangeImag = 30)
-                            # zRangeAbs = 800, zRangeImag = 30)
+          plotComplexMatrix(
+            complexMatrix     = momentResultInBin.integralMatrix.matrixNormalized,
+            pdfFileNamePrefix = f"{outFileDirName}/accMatrix_{label}_",
+            axisTitles        = ("Physical Moment Index", "Measured Moment Index"),
+            plotTitle         = f"{label}: "r"$\mathrm{\mathbf{I}}_\text{acc}$, ",
+            zRangeAbs         = 1.5,
+            zRangeImag        = 0.25,
+          )
+          plotComplexMatrix(
+            complexMatrix     = momentResultInBin.integralMatrix.inverse,
+            pdfFileNamePrefix = f"{outFileDirName}/accMatrixInv_{label}_",
+            axisTitles        = ("Measured Moment Index", "Physical Moment Index"),
+            plotTitle         = f"{label}: "r"$\mathrm{\mathbf{I}}_\text{acc}^{-1}$, ",
+            zRangeAbs         = 115,
+            # zRangeAbs         = 800,
+            zRangeImag        = 30,
+          )
 
     if calcAccPsMoments:
       # calculate moments of accepted phase-space data
@@ -266,13 +296,31 @@ if __name__ == "__main__":
           # set H_0^meas(0, 0) to 0 so that one can better see the other H_0^meas moments
           momentResultInBin.HMeas._valsFlatIndex[0] = 0
           # plot measured and physical moments; the latter should match the true moments exactly except for tiny numerical effects
-          plotMomentsInBin(momentResultInBin.HMeas, normalizeMoments,                  pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{label}_accPs_", plotLegend = False)
-          # plotMomentsInBin(momentResultInBin.HPhys, normalizeMoments, HTrue = HTruePs, pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{label}_accPsCorr_")
+          plotMomentsInBin(
+            HData             = momentResultInBin.HMeas,
+            normalizedMoments = normalizeMoments,
+            HTrue             = None,
+            pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{label}_accPs_",
+            plotLegend        = False,
+          )
+          # plotMomentsInBin(
+          #   HData             = momentResultInBin.HPhys,
+          #   normalizedMoments = normalizeMoments,
+          #   HTrue             = HTruePs,
+          #   pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{label}_accPsCorr_",
+          # )
         # plot kinematic dependences of all phase-space moments
         for qnIndex in momentIndices.QnIndices():
           HVals = tuple(MomentValueAndTruth(*momentsInBin.HMeas[qnIndex]) for momentsInBin in moments)
-          plotMoments(HVals, massBinning, normalizeMoments, momentLabel = qnIndex.label,
-                      pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{massBinning.var.name}_accPs_", histTitle = qnIndex.title, plotLegend = False)
+          plotMoments(
+            HVals             = HVals,
+            binning           = massBinning,
+            normalizedMoments = normalizeMoments,
+            momentLabel       = qnIndex.label,
+            pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{massBinning.var.name}_accPs_",
+            histTitle         = qnIndex.title,
+            plotLegend        = False,
+          )
 
     # calculate moments of real data and write them to files
     with timer.timeThis(f"Time to calculate moments of real data for {len(moments)} bins using {nmbOpenMpThreads} OpenMP threads"):
@@ -293,7 +341,13 @@ if __name__ == "__main__":
         dataPsAcc = ROOT.RDataFrame(treeName, psAccFileName)
         print(f"Loading generated phase-space data from tree '{treeName}' in file '{psGenFileName}'")
         dataPsGen = ROOT.RDataFrame(treeName, psGenFileName)
-        plotAngularDistr(dataPsAcc, dataPsGen, data, dataSignalGen = None, pdfFileNamePrefix = f"{outFileDirName}/angDistr_total_")
+        plotAngularDistr(
+          dataPsAcc         = dataPsAcc,
+          dataPsGen         = dataPsGen,
+          dataSignalAcc     = data,
+          dataSignalGen     = None,
+          pdfFileNamePrefix = f"{outFileDirName}/angDistr_total_",
+        )
 
       # load moment results from files
       momentResultsTrue = MomentResultsKinematicBinning.load(f"{outFileDirName}/{namePrefix}_moments_true.pkl")
@@ -323,8 +377,12 @@ if __name__ == "__main__":
           plotLegend        = False,
         )
         #TODO also plot correlation matrices
-        plotMomentsCovMatrices(HPhys, pdfFileNamePrefix = f"{outFileDirName}/covMatrix_{label}_",
-                               axisTitles = ("Physical Moment Index", "Physical Moment Index"), plotTitle = f"{label}: ")
+        plotMomentsCovMatrices(
+          HData             = HPhys,
+          pdfFileNamePrefix = f"{outFileDirName}/covMatrix_{label}_",
+          axisTitles        = ("Physical Moment Index", "Physical Moment Index"),
+          plotTitle         = f"{label}: ",
+        )
         if nmbBootstrapSamples > 0:
           graphTitle = f"({label})"
           plotMomentsBootstrapDistributions1D(
@@ -332,9 +390,17 @@ if __name__ == "__main__":
             HTrue             = HTrue,
             pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{label}_",
             histTitle         = title)
-          plotMomentsBootstrapDistributions2D(HPhys, HTrue,
-                                              pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{label}_", histTitle = title)
-          plotMomentsBootstrapDiffInBin(HPhys, pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{label}_", graphTitle = title)
+          plotMomentsBootstrapDistributions2D(
+            HData             = HPhys,
+            HTrue             = HTrue,
+            pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{label}_",
+            histTitle         = title,
+          )
+          plotMomentsBootstrapDiffInBin(
+            HData             = HPhys,
+            pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{label}_",
+            graphTitle        = title,
+          )
 
       # plot kinematic dependences of all moments
       for qnIndex in momentResultsPhys[0].indices.QnIndices():

--- a/momentsPhotoProdEtaPi0.py
+++ b/momentsPhotoProdEtaPi0.py
@@ -310,7 +310,7 @@ if __name__ == "__main__":
           #   pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{label}_accPsCorr_",
           # )
         # plot kinematic dependences of all phase-space moments
-        for qnIndex in momentIndices.QnIndices:
+        for qnIndex in momentIndices.qnIndices:
           HVals = tuple(MomentValueAndTruth(*momentsInBin.HMeas[qnIndex]) for momentsInBin in moments)
           plotMoments(
             HVals             = HVals,
@@ -403,7 +403,7 @@ if __name__ == "__main__":
           )
 
       # plot kinematic dependences of all moments
-      for qnIndex in momentResultsPhys[0].indices.QnIndices:
+      for qnIndex in momentResultsPhys[0].indices.qnIndices:
         plotMoments1D(
           momentResults     = momentResultsPhys,
           qnIndex           = qnIndex,

--- a/momentsPhotoProdEtaPi0.py
+++ b/momentsPhotoProdEtaPi0.py
@@ -388,16 +388,18 @@ if __name__ == "__main__":
       canv.SaveAs(f"{outFileDirName}/{histRatio.GetName()}.pdf")
 
       # overlay H_0^meas(0, 0) and measured intensity distribution; must be identical
-      histIntMeas = data.Histo1D(
-        ROOT.RDF.TH1DModel("intensity_meas", f";{massBinning.axisTitle};Events", *massBinning.astuple), "mass", "eventWeight").GetValue()
+      histIntMeas = ROOT.RDataFrame(treeName, dataFileName) \
+                        .Histo1D(
+                          ROOT.RDF.TH1DModel("intensity_meas", f";{massBinning.axisTitle};Events", *massBinning.astuple), "mass", "eventWeight"
+                        ).GetValue()
       for binIndex, HMeas in enumerate(H000s[0]):
-        HMeas.truth = histIntMeas.GetBinContent(binIndex + 1)
+        HMeas.truth = histIntMeas.GetBinContent(binIndex + 1)  # set truth values to measured intensity
       plotMoments(
         HVals             = H000s[0],
         binning           = massBinning,
         normalizedMoments = normalizeMoments,
         momentLabel       = H000Index.label,
-        pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_meas_",
+        pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_meas_intensity_",
         histTitle         = H000Index.title,
         legendLabels      = ("Measured Moment", "Measured Intensity"),
       )

--- a/momentsPhotoProdEtaPi0.py
+++ b/momentsPhotoProdEtaPi0.py
@@ -373,6 +373,7 @@ if __name__ == "__main__":
         plotMomentsInBin(
           HData             = HMeas,
           normalizedMoments = normalizeMoments,
+          HTrue             = None,
           pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_meas_{label}_",
           plotLegend        = False,
         )
@@ -419,6 +420,7 @@ if __name__ == "__main__":
           qnIndex           = qnIndex,
           binning           = massBinning,
           normalizedMoments = normalizeMoments,
+          momentResultsTrue = None,
           pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_meas_",
           histTitle         = qnIndex.title,
           plotLegend        = False,

--- a/momentsPhotoProdEtaPi0.py
+++ b/momentsPhotoProdEtaPi0.py
@@ -310,7 +310,7 @@ if __name__ == "__main__":
           #   pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{label}_accPsCorr_",
           # )
         # plot kinematic dependences of all phase-space moments
-        for qnIndex in momentIndices.QnIndices():
+        for qnIndex in momentIndices.QnIndices:
           HVals = tuple(MomentValueAndTruth(*momentsInBin.HMeas[qnIndex]) for momentsInBin in moments)
           plotMoments(
             HVals             = HVals,
@@ -403,7 +403,7 @@ if __name__ == "__main__":
           )
 
       # plot kinematic dependences of all moments
-      for qnIndex in momentResultsPhys[0].indices.QnIndices():
+      for qnIndex in momentResultsPhys[0].indices.QnIndices:
         plotMoments1D(
           momentResults     = momentResultsPhys,
           qnIndex           = qnIndex,

--- a/momentsPhotoProdEtaPi0.py
+++ b/momentsPhotoProdEtaPi0.py
@@ -1,16 +1,14 @@
 #!/usr/bin/env python3
 # performs moments analysis for eta pi0 real-data events
 
+
+from __future__ import annotations
+
 from dataclasses import dataclass
 import functools
 import numpy as np
 import pandas as pd
 import threadpoolctl
-from typing import (
-  Dict,
-  List,
-  Tuple,
-)  #TODO Python 3.9 allows standard collections to be used in type annotations
 
 import ROOT
 
@@ -62,7 +60,7 @@ class BeamPolInfo:
 # see Eqs. (4.22)ff in Lawrence's thesis for polarization values and
 # /w/halld-scshelf2101/malte/final_fullWaveset/nominal_fullWaveset_ReflIndiv_150rnd/010020/etapi_result_samePhaseD.fit
 # for amplitude scaling factors
-BEAM_POL_INFOS: Tuple[BeamPolInfo, ...] = (
+BEAM_POL_INFOS: tuple[BeamPolInfo, ...] = (
   BeamPolInfo(datasetLabel = "EtaPi0_000", angle =   0, polarization = 0.35062, ampScaleFactor = 1.0),
   BeamPolInfo(datasetLabel = "EtaPi0_045", angle =  45, polarization = 0.34230, ampScaleFactor = 0.982204395837131),
   BeamPolInfo(datasetLabel = "EtaPi0_090", angle =  90, polarization = 0.34460, ampScaleFactor = 0.968615883555624),
@@ -75,7 +73,7 @@ def readPartialWaveAmplitudes(
   massBinCenter:     float,  # [GeV]
   fitResultPlotDir:  str,    # directory with intensity plots generated from PWA fit result
   beamPolAngleLabel: str = "000",  # "total" for total data sample summed over polarization directions
-) -> List[AmplitudeValue]:
+) -> list[AmplitudeValue]:
   """Reads partial-wave amplitude values for given mass bin from CSV data"""
   print(f"Reading partial-wave amplitudes for mass bin at {massBinCenter} GeV from file '{csvFileName}'")
   df = pd.read_csv(csvFileName, index_col = [0]).astype({"mass": float})
@@ -184,9 +182,9 @@ if __name__ == "__main__":
 
     # setup MomentCalculators for all mass bins
     momentIndices = MomentIndices(maxL)
-    momentsInBins:    List[MomentCalculator] = []
-    momentsInBinsPwa: List[MomentCalculator] = []
-    nmbPsGenEvents:   List[int]              = []
+    momentsInBins:    list[MomentCalculator] = []
+    momentsInBinsPwa: list[MomentCalculator] = []
+    nmbPsGenEvents:   list[int]              = []
     assert len(massBinning) > 0, f"Need at least one mass bin, but found {len(massBinning)}"
     with timer.timeThis(f"Time to load data and setup MomentCalculators for {len(massBinning)} bins"):
       for massBinIndex, massBinCenter in enumerate(massBinning):

--- a/momentsPhotoProdPiPiUnpol.py
+++ b/momentsPhotoProdPiPiUnpol.py
@@ -191,7 +191,7 @@ if __name__ == "__main__":
           #   pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{label}_accPsCorr_"
           # )
         # plot kinematic dependences of all phase-space moments
-        for qnIndex in momentIndices.QnIndices():
+        for qnIndex in momentIndices.qnIndices:
           HVals = tuple(MomentValueAndTruth(*momentsInBin.HMeas[qnIndex]) for momentsInBin in moments)
           plotMoments(
             HVals             = HVals,
@@ -282,7 +282,7 @@ if __name__ == "__main__":
           )
 
       # plot kinematic dependences of all moments
-      for qnIndex in momentResultsPhys[0].indices.QnIndices():
+      for qnIndex in momentResultsPhys[0].indices.qnIndices:
         plotMoments1D(
           momentResults     = momentResultsPhys,
           qnIndex           = qnIndex,

--- a/momentsPhotoProdPiPiUnpol.py
+++ b/momentsPhotoProdPiPiUnpol.py
@@ -131,7 +131,7 @@ if __name__ == "__main__":
     psAccFileName            = f"./dataPhotoProdPiPiUnpol/phaseSpace_acc_flat.root"
     psGenFileName            = f"./dataPhotoProdPiPiUnpol/phaseSpace_gen_flat.root"
     outFileDirName           = Utilities.makeDirPath(f"./plotsPhotoProdPiPiUnpol")
-    maxL                     = 4  # define maximum L quantum number of moments
+    maxL                     = 5  # define maximum L quantum number of moments
     normalizeMoments         = False
     nmbBootstrapSamples      = 0
     # nmbBootstrapSamples      = 10000

--- a/momentsPhotoProdPiPiUnpol.py
+++ b/momentsPhotoProdPiPiUnpol.py
@@ -308,12 +308,12 @@ if __name__ == "__main__":
       scaleFactor =   momentResultsPhys[normMassBinIndex][H000Index].val.real \
                     / momentResultsClas[normMassBinIndex][H000Index].val.real
       momentResultsClas.scaleBy(scaleFactor)
-      print(f"!!!\n{momentResultsPhys[36]}\n!!! vs.\n{momentResultsClas[36]}")
-      #TODO add comparison of moments with CLAS results
+      # print(f"!!!\n{momentResultsPhys[36]}\n!!! vs.\n{momentResultsClas[36]}")
 
       # plot moments in each kinematic bin
       for massBinIndex, HPhys in enumerate(momentResultsPhys):
         HMeas = momentResultsMeas[massBinIndex]
+        HClas = momentResultsClas[massBinIndex]
         label = binLabel(HPhys)
         title = binTitle(HPhys)
         # print(f"True moments for kinematic bin {title}:\n{HTrue}")
@@ -322,9 +322,9 @@ if __name__ == "__main__":
         plotMomentsInBin(
           HData             = HPhys,
           normalizedMoments = normalizeMoments,
-          HTrue             = None,
+          HTrue             = HClas,
           pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{label}_",
-          legendLabels      = ("Moment", "PWA Result"),
+          legendLabels      = ("Moment", "CLAS"),
         )
         plotMomentsInBin(
           HData             = HMeas,
@@ -344,14 +344,17 @@ if __name__ == "__main__":
           graphTitle = f"({label})"
           plotMomentsBootstrapDistributions1D(
             HData             = HPhys,
-            HTrue             = None,
-            pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{label}_",
-            histTitle         = title)
-          plotMomentsBootstrapDistributions2D(
-            HData             = HPhys,
-            HTrue             = None,
+            HTrue             = HClas,
             pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{label}_",
             histTitle         = title,
+            HTrueLabel        = "CLAS",
+          )
+          plotMomentsBootstrapDistributions2D(
+            HData             = HPhys,
+            HTrue             = HClas,
+            pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{label}_",
+            histTitle         = title,
+            HTrueLabel        = "CLAS",
           )
           plotMomentsBootstrapDiffInBin(
             HData             = HPhys,
@@ -366,10 +369,10 @@ if __name__ == "__main__":
           qnIndex           = qnIndex,
           binning           = massBinning,
           normalizedMoments = normalizeMoments,
-          momentResultsTrue = None,
+          momentResultsTrue = momentResultsClas,
           pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_",
           histTitle         = qnIndex.title,
-          legendLabels      = ("Moment", "PWA Result"),
+          legendLabels      = ("Moment", "CLAS"),
         )
         plotMoments1D(
           momentResults     = momentResultsMeas,

--- a/momentsPhotoProdPiPiUnpol.py
+++ b/momentsPhotoProdPiPiUnpol.py
@@ -82,7 +82,7 @@ def readMomentResultsClas(
             names    = ["mass", "massLow", "massHigh", "moment", "uncertPlus", "uncertMinus"],
           )
           # scale moment values and their uncertainties by 1 / sqrt(2L + 1) to match normalization used in this analysis
-          momentDf["moment", "uncertPlus", "uncertMinus"] /= np.sqrt(2 * qnMomentIndex.L + 1)
+          momentDf[["moment", "uncertPlus", "uncertMinus"]] /= np.sqrt(2 * qnMomentIndex.L + 1)
           momentDfs[qnMomentIndex] = momentDf
           break
   # ensure that mass bins are the same in all data frames

--- a/momentsPhotoProdPiPiUnpol.py
+++ b/momentsPhotoProdPiPiUnpol.py
@@ -82,7 +82,7 @@ def readMomentResultsClas(
             skiprows = 3,  # 2 rows with comments and 1 row with column names; the latter cannot be parsed by pandas
             names    = ["mass", "massLow", "massHigh", "moment", "uncertPlus", "uncertMinus"],
           )
-          print(f"!!! {qnMomentIndex=}\n{momentDfs[qnMomentIndex]}")
+          # print(f"!!! {qnMomentIndex=}\n{momentDfs[qnMomentIndex]}")
           break
   # check that mass bins are the same in all data frames
   dfs = list(momentDfs.values())
@@ -302,6 +302,13 @@ if __name__ == "__main__":
       momentResultsMeas = MomentResultsKinematicBinning.load(f"{outFileDirName}/{namePrefix}_moments_meas.pkl")
       momentResultsPhys = MomentResultsKinematicBinning.load(f"{outFileDirName}/{namePrefix}_moments_phys.pkl")
       momentResultsClas = readMomentResultsClas(momentIndices, binVarMass)
+      # normalize CLAS moments
+      H000Index = QnMomentIndex(momentIndex = 0, L = 0, M =0)
+      normMassBinIndex = 36  # corresponds to m_pipi = 0.765 GeV; in this bin H(0, 0) is maximal in CLAS and GlueX data
+      scaleFactor =   momentResultsPhys[normMassBinIndex][H000Index].val.real \
+                    / momentResultsClas[normMassBinIndex][H000Index].val.real
+      momentResultsClas.scaleBy(scaleFactor)
+      print(f"!!!\n{momentResultsPhys[36]}\n!!! vs.\n{momentResultsClas[36]}")
       #TODO add comparison of moments with CLAS results
 
       # plot moments in each kinematic bin
@@ -376,7 +383,6 @@ if __name__ == "__main__":
         )
 
       # plot ratio of measured and physical value for Re[H_0(0, 0)]; estimates efficiency
-      H000Index = QnMomentIndex(momentIndex = 0, L = 0, M =0)
       H000s = (
         tuple(MomentValueAndTruth(*HMeas[H000Index]) for HMeas in momentResultsMeas),
         tuple(MomentValueAndTruth(*HPhys[H000Index]) for HPhys in momentResultsPhys),

--- a/momentsPhotoProdPiPiUnpol.py
+++ b/momentsPhotoProdPiPiUnpol.py
@@ -97,9 +97,7 @@ def readMomentResultsClas(
     momentValues: list[MomentValue] = []
     for qnMomentIndex, momentDf in momentDfs.items():
       mask = momentDf["mass"] == massBinCenter
-      moment      = momentDf[mask]["moment"     ].values[0]
-      uncertPlus  = momentDf[mask]["uncertPlus" ].values[0]
-      uncertMinus = momentDf[mask]["uncertMinus"].values[0]
+      moment, uncertPlus, uncertMinus = momentDf[mask][["moment", "uncertPlus", "uncertMinus"]].values[0]
       assert uncertPlus == -uncertMinus, f"Uncertainties are not symmetric: {uncertPlus} vs. {uncertMinus}"
       momentValues.append(
         MomentValue(

--- a/momentsPhotoProdPiPiUnpol.py
+++ b/momentsPhotoProdPiPiUnpol.py
@@ -76,15 +76,16 @@ def readMomentResultsClas(
           assert tableStartPos >= 0, f"Could not find table for beam energy bin '{beamEnergyBinLabel}' in file '{csvFileName}'"
           tableEndPos = csvData.find("\n\n", tableStartPos)  # tables are separated by an empty line
           csvData = csvData[tableStartPos:tableEndPos if tableEndPos >= 0 else None]
-          # print(f"!!! {qnMomentIndex=}\n{csvData=}")
-          momentDfs[qnMomentIndex] = pd.read_csv(
+          momentDf = pd.read_csv(
             StringIO(csvData),
             skiprows = 3,  # 2 rows with comments and 1 row with column names; the latter cannot be parsed by pandas
             names    = ["mass", "massLow", "massHigh", "moment", "uncertPlus", "uncertMinus"],
           )
-          # print(f"!!! {qnMomentIndex=}\n{momentDfs[qnMomentIndex]}")
+          # scale moment values and their uncertainties by 1 / sqrt(2L + 1) to match normalization used in this analysis
+          momentDf["moment", "uncertPlus", "uncertMinus"] /= np.sqrt(2 * qnMomentIndex.L + 1)
+          momentDfs[qnMomentIndex] = momentDf
           break
-  # check that mass bins are the same in all data frames
+  # ensure that mass bins are the same in all data frames
   dfs = list(momentDfs.values())
   massColunm = dfs[0]["mass"]
   for df in dfs[1:]:

--- a/momentsPhotoProdPiPiUnpol.py
+++ b/momentsPhotoProdPiPiUnpol.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+# performs moments analysis for pi+ pi- real-data events in CLAS energy range
+
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import functools
+import numpy as np
+import threadpoolctl
+
+import ROOT
+
+from MomentCalculator import (
+  binLabel,
+  binTitle,
+  DataSet,
+  KinematicBinningVariable,
+  MomentCalculator,
+  MomentCalculatorsKinematicBinning,
+  MomentIndices,
+  MomentResult,
+  MomentResultsKinematicBinning,
+  QnMomentIndex,
+)
+from PlottingUtilities import (
+  HistAxisBinning,
+  MomentValueAndTruth,
+  plotAngularDistr,
+  plotComplexMatrix,
+  plotMoments,
+  plotMoments1D,
+  plotMomentsBootstrapDiffInBin,
+  plotMomentsBootstrapDistributions1D,
+  plotMomentsBootstrapDistributions2D,
+  plotMomentsCovMatrices,
+  plotMomentsInBin,
+  setupPlotStyle,
+)
+import RootUtilities  # importing initializes OpenMP and loads basisFunctions.C
+import Utilities
+
+
+# always flush print() to reduce garbling of log files due to buffering
+print = functools.partial(print, flush = True)
+
+
+if __name__ == "__main__":
+  Utilities.printGitInfo()
+  timer = Utilities.Timer()
+  ROOT.gROOT.SetBatch(True)
+  setupPlotStyle()
+  threadController = threadpoolctl.ThreadpoolController()  # at this point all multi-threading libraries must be loaded
+  print(f"Initial state of ThreadpoolController before setting number of threads:\n{threadController.info()}")
+  with threadController.limit(limits = 4):
+    print(f"State of ThreadpoolController after setting number of threads:\n{threadController.info()}")
+    timer.start("Total execution time")
+
+    # set parameters of analysis
+    treeName                 = "PiPi"
+    dataFileName             = f"./dataPhotoProdPiPiUnpol/data_flat.root"
+    psAccFileName            = f"./dataPhotoProdPiPiUnpol/phaseSpace_acc_flat.root"
+    psGenFileName            = f"./dataPhotoProdPiPiUnpol/phaseSpace_gen_flat.root"
+    outFileDirName           = Utilities.makeDirPath(f"./plotsPhotoProdPiPiUnpol")
+    maxL                     = 5  # define maximum L quantum number of moments
+    normalizeMoments         = False
+    nmbBootstrapSamples      = 0
+    # nmbBootstrapSamples      = 10000
+    # plotAngularDistributions = True
+    plotAngularDistributions = False
+    # plotAccIntegralMatrices  = True
+    plotAccIntegralMatrices  = False
+    # calcAccPsMoments         = True
+    calcAccPsMoments         = False
+    binVarMass               = KinematicBinningVariable(name = "mass", label = "#it{m}_{#it{#pi}^{#plus}#it{#pi}^{#minus}}", unit = "GeV/#it{c}^{2}", nmbDigits = 2)
+    massBinning              = HistAxisBinning(nmbBins = 100, minVal = 0.4, maxVal = 1.4, _var = binVarMass)  # same binning as used by CLAS
+    # massBinning              = HistAxisBinning(nmbBins = 1, minVal = 1.25, maxVal = 1.29, _var = binVarMass)  # f_2(1270) region
+    nmbOpenMpThreads         = ROOT.getNmbOpenMpThreads()
+
+    namePrefix = "norm" if normalizeMoments else "unnorm"
+
+    # setup MomentCalculators for all mass bins
+    momentIndices = MomentIndices(maxL)
+    momentsInBins:  list[MomentCalculator] = []
+    nmbPsGenEvents: list[int]              = []
+    assert len(massBinning) > 0, f"Need at least one mass bin, but found {len(massBinning)}"
+    with timer.timeThis(f"Time to load data and setup MomentCalculators for {len(massBinning)} bins"):
+      for massBinIndex, massBinCenter in enumerate(massBinning):
+        massBinRange = massBinning.binValueRange(massBinIndex)
+        print(f"Preparing {binVarMass.name} bin [{massBinIndex} of {len(massBinning)}] at {massBinCenter} {binVarMass.unit} with range {massBinRange} {binVarMass.unit}")
+
+        # load data for mass bin
+        binMassRangeFilter = f"(({massBinRange[0]} < {binVarMass.name}) && ({binVarMass.name} < {massBinRange[1]}))"
+        print(f"Loading real data from tree '{treeName}' in file '{dataFileName}' and applying filter {binMassRangeFilter}")
+        dataInBin = ROOT.RDataFrame(treeName, dataFileName).Filter(binMassRangeFilter)
+        print(f"Loaded {dataInBin.Count().GetValue()} data events; {dataInBin.Sum('eventWeight').GetValue()} background subtracted events")
+        print(f"Loading accepted phase-space data from tree '{treeName}' in file '{psAccFileName}' and applying filter {binMassRangeFilter}")
+        dataPsAccInBin = ROOT.RDataFrame(treeName, psAccFileName).Filter(binMassRangeFilter)
+        print(f"Loading generated phase-space data from tree '{treeName}' in file '{psAccFileName}' and applying filter {binMassRangeFilter}")
+        dataPsGenInBin = ROOT.RDataFrame(treeName, psGenFileName).Filter(binMassRangeFilter)
+        nmbPsGenEvents.append(dataPsGenInBin.Count().GetValue())
+        nmbPsAccEvents = dataPsAccInBin.Count().GetValue()
+        print(f"Loaded phase-space events: number generated = {nmbPsGenEvents[-1]}; "
+              f"number accepted = {nmbPsAccEvents}, "
+              f" -> efficiency = {nmbPsAccEvents / nmbPsGenEvents[-1]:.3f}")
+
+        # setup moment calculators for data
+        dataSet = DataSet(
+          data           = dataInBin,
+          phaseSpaceData = dataPsAccInBin,
+          nmbGenEvents   = nmbPsGenEvents[-1],
+          polarization   = None,
+        )
+        momentsInBins.append(
+          MomentCalculator(
+            indices              = momentIndices,
+            dataSet              = dataSet,
+            binCenters           = {binVarMass : massBinCenter},
+            integralFileBaseName = f"{outFileDirName}/integralMatrix",
+          )
+        )
+
+        # plot angular distributions for mass bin
+        if plotAngularDistributions:
+          plotAngularDistr(
+            dataPsAcc         = dataPsAccInBin,
+            dataPsGen         = dataPsGenInBin,
+            dataSignalAcc     = dataInBin,
+            dataSignalGen     = None,
+            pdfFileNamePrefix = f"{outFileDirName}/angDistr_{binLabel(momentsInBins[-1])}_"
+          )
+    moments = MomentCalculatorsKinematicBinning(momentsInBins)
+
+    # calculate and plot integral matrix for all mass bins
+    with timer.timeThis(f"Time to calculate integral matrices for {len(moments)} bins using {nmbOpenMpThreads} OpenMP threads"):
+      print(f"Calculating acceptance integral matrices for {len(moments)} bins using {nmbOpenMpThreads} OpenMP threads")
+      moments.calculateIntegralMatrices(forceCalculation = True)
+      print(f"Acceptance integral matrix for first bin at {massBinning[0]} {binVarMass.unit}:\n{moments[0].integralMatrix}")
+      eigenVals, _ = moments[0].integralMatrix.eigenDecomp
+      print(f"Sorted eigenvalues of acceptance integral matrix for first bin at {massBinning[0]} {binVarMass.unit}:\n{np.sort(eigenVals)}")
+      # plot acceptance integral matrices for all kinematic bins
+      if plotAccIntegralMatrices:
+        for momentResultInBin in moments:
+          label = binLabel(momentResultInBin)
+          plotComplexMatrix(
+            complexMatrix     = momentResultInBin.integralMatrix.matrixNormalized,
+            pdfFileNamePrefix = f"{outFileDirName}/accMatrix_{label}_",
+            axisTitles        = ("Physical Moment Index", "Measured Moment Index"),
+            plotTitle         = f"{label}: "r"$\mathrm{\mathbf{I}}_\text{acc}$, ",
+            zRangeAbs         = 1.2,
+            zRangeImag        = 0.05,
+          )
+          plotComplexMatrix(
+            complexMatrix     = momentResultInBin.integralMatrix.inverse,
+            pdfFileNamePrefix = f"{outFileDirName}/accMatrixInv_{label}_",
+            axisTitles        = ("Measured Moment Index", "Physical Moment Index"),
+            plotTitle         = f"{label}: "r"$\mathrm{\mathbf{I}}_\text{acc}^{-1}$, ",
+            zRangeAbs         = 5,
+            zRangeImag        = 0.3,
+          )
+
+    if calcAccPsMoments:
+      # calculate moments of accepted phase-space data
+      with timer.timeThis(f"Time to calculate moments of phase-space MC data using {nmbOpenMpThreads} OpenMP threads"):
+        print(f"Calculating moments of phase-space MC data for {len(moments)} bins using {nmbOpenMpThreads} OpenMP threads")
+        moments.calculateMoments(dataSource = MomentCalculator.MomentDataSource.ACCEPTED_PHASE_SPACE, normalize = normalizeMoments)
+        # plot accepted phase-space moments in each kinematic bin
+        #TODO move into separate plotting script
+        for massBinIndex, momentResultInBin in enumerate(moments):
+          label = binLabel(momentResultInBin)
+          title = binTitle(momentResultInBin)
+          print(f"Measured moments of accepted phase-space data for kinematic bin {title}:\n{momentResultInBin.HMeas}")
+          print(f"Physical moments of accepted phase-space data for kinematic bin {title}:\n{momentResultInBin.HPhys}")
+          # construct true moments for phase-space data
+          HTruePs = MomentResult(momentIndices, label = "true")  # all true phase-space moments are 0 ...
+          HTruePs._valsFlatIndex[momentIndices[QnMomentIndex(momentIndex = 0, L = 0, M = 0)]] = 1 if normalizeMoments else nmbPsGenEvents[massBinIndex]  # ... except for H_0(0, 0)
+          # set H_0^meas(0, 0) to 0 so that one can better see the other H_0^meas moments
+          momentResultInBin.HMeas._valsFlatIndex[0] = 0
+          # plot measured and physical moments; the latter should match the true moments exactly except for tiny numerical effects
+          plotMomentsInBin(
+            HData             = momentResultInBin.HMeas,
+            normalizedMoments = normalizeMoments,
+            HTrue             = None,
+            pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{label}_accPs_",
+            plotLegend        = False,
+          )
+          # plotMomentsInBin(
+          #   HData             = momentResultInBin.HPhys,
+          #   normalizedMoments = normalizeMoments,
+          #   HTrue             = HTruePs,
+          #   pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{label}_accPsCorr_"
+          # )
+        # plot kinematic dependences of all phase-space moments
+        for qnIndex in momentIndices.QnIndices():
+          HVals = tuple(MomentValueAndTruth(*momentsInBin.HMeas[qnIndex]) for momentsInBin in moments)
+          plotMoments(
+            HVals             = HVals,
+            binning           = massBinning,
+            normalizedMoments = normalizeMoments,
+            momentLabel       = qnIndex.label,
+            pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{massBinning.var.name}_accPs_",
+            histTitle         = qnIndex.title,
+            plotLegend        = False,
+          )
+
+    # calculate moments of real data and write them to files
+    with timer.timeThis(f"Time to calculate moments of real data for {len(moments)} bins using {nmbOpenMpThreads} OpenMP threads"):
+      print(f"Calculating moments of real data for {len(moments)} bins using {nmbOpenMpThreads} OpenMP threads")
+      moments.calculateMoments(normalize = normalizeMoments, nmbBootstrapSamples = nmbBootstrapSamples)
+      moments.momentResultsMeas.save(f"{outFileDirName}/{namePrefix}_moments_meas.pkl")
+      moments.momentResultsPhys.save(f"{outFileDirName}/{namePrefix}_moments_phys.pkl")
+
+    #TODO move into separate plotting script
+    with timer.timeThis(f"Time to plot moments of real data"):
+      if plotAngularDistributions:
+        print("Plotting total angular distributions")
+        # load all signal and phase-space data
+        print(f"Loading real data from tree '{treeName}' in file '{dataFileName}'")
+        data = ROOT.RDataFrame(treeName, dataFileName)
+        print(f"Loading accepted phase-space data from tree '{treeName}' in file '{psAccFileName}'")
+        dataPsAcc = ROOT.RDataFrame(treeName, psAccFileName)
+        print(f"Loading generated phase-space data from tree '{treeName}' in file '{psGenFileName}'")
+        dataPsGen = ROOT.RDataFrame(treeName, psGenFileName)
+        plotAngularDistr(
+          dataPsAcc         = dataPsAcc,
+          dataPsGen         = dataPsGen,
+          dataSignalAcc     = data,
+          dataSignalGen     = None,
+          pdfFileNamePrefix = f"{outFileDirName}/angDistr_total_",
+        )
+
+      # load moment results from files
+      momentResultsMeas = MomentResultsKinematicBinning.load(f"{outFileDirName}/{namePrefix}_moments_meas.pkl")
+      momentResultsPhys = MomentResultsKinematicBinning.load(f"{outFileDirName}/{namePrefix}_moments_phys.pkl")
+
+      # plot moments in each kinematic bin
+      for massBinIndex, HPhys in enumerate(momentResultsPhys):
+        HMeas = momentResultsMeas[massBinIndex]
+        label = binLabel(HPhys)
+        title = binTitle(HPhys)
+        # print(f"True moments for kinematic bin {title}:\n{HTrue}")
+        print(f"Measured moments of real data for kinematic bin {title}:\n{HMeas}")
+        print(f"Physical moments of real data for kinematic bin {title}:\n{HPhys}")
+        plotMomentsInBin(
+          HData             = HPhys,
+          normalizedMoments = normalizeMoments,
+          HTrue             = None,
+          pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{label}_",
+          legendLabels      = ("Moment", "PWA Result"),
+        )
+        plotMomentsInBin(
+          HData             = HMeas,
+          normalizedMoments = normalizeMoments,
+          HTrue             = None,
+          pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_meas_{label}_",
+          plotLegend        = False,
+        )
+        #TODO also plot correlation matrices
+        plotMomentsCovMatrices(
+          HData             = HPhys,
+          pdfFileNamePrefix = f"{outFileDirName}/covMatrix_{label}_",
+          axisTitles        = ("Physical Moment Index", "Physical Moment Index"),
+          plotTitle         = f"{label}: ",
+        )
+        if nmbBootstrapSamples > 0:
+          graphTitle = f"({label})"
+          plotMomentsBootstrapDistributions1D(
+            HData             = HPhys,
+            HTrue             = None,
+            pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{label}_",
+            histTitle         = title)
+          plotMomentsBootstrapDistributions2D(
+            HData             = HPhys,
+            HTrue             = None,
+            pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{label}_",
+            histTitle         = title,
+          )
+          plotMomentsBootstrapDiffInBin(
+            HData             = HPhys,
+            pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{label}_",
+            graphTitle        = title,
+          )
+
+      # plot kinematic dependences of all moments
+      for qnIndex in momentResultsPhys[0].indices.QnIndices():
+        plotMoments1D(
+          momentResults     = momentResultsPhys,
+          qnIndex           = qnIndex,
+          binning           = massBinning,
+          normalizedMoments = normalizeMoments,
+          momentResultsTrue = None,
+          pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_",
+          histTitle         = qnIndex.title,
+          legendLabels      = ("Moment", "PWA Result"),
+        )
+        plotMoments1D(
+          momentResults     = momentResultsMeas,
+          qnIndex           = qnIndex,
+          binning           = massBinning,
+          normalizedMoments = normalizeMoments,
+          momentResultsTrue = None,
+          pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_meas_",
+          histTitle         = qnIndex.title,
+          plotLegend        = False,
+        )
+
+      # plot ratio of measured and physical value for Re[H_0(0, 0)]; estimates efficiency
+      H000Index = QnMomentIndex(momentIndex = 0, L = 0, M =0)
+      H000s = (
+        tuple(MomentValueAndTruth(*HMeas[H000Index]) for HMeas in momentResultsMeas),
+        tuple(MomentValueAndTruth(*HPhys[H000Index]) for HPhys in momentResultsPhys),
+      )
+      hists = (
+        ROOT.TH1D(f"H000Meas", "", *massBinning.astuple),
+        ROOT.TH1D(f"H000Phys", "", *massBinning.astuple),
+      )
+      for indexMeasPhys, H000 in enumerate(H000s):
+        histIntensity = hists[indexMeasPhys]
+        for indexKinBin, HVal in enumerate(H000):
+          if (massBinning._var not in HVal.binCenters.keys()):
+            continue
+          y, yErr = HVal.realPart(True)
+          binIndex = histIntensity.GetXaxis().FindBin(HVal.binCenters[massBinning.var])
+          histIntensity.SetBinContent(binIndex, y)
+          histIntensity.SetBinError  (binIndex, 1e-100 if yErr < 1e-100 else yErr)
+      histRatio = hists[0].Clone("H000Ratio")
+      histRatio.Divide(hists[1])
+      canv = ROOT.TCanvas()
+      histRatio.SetMarkerStyle(ROOT.kFullCircle)
+      histRatio.SetMarkerSize(0.75)
+      histRatio.SetXTitle(massBinning.axisTitle)
+      histRatio.SetYTitle("#it{H}_{0}^{meas}(0, 0) / #it{H}_{0}^{phys}(0, 0)")
+      histRatio.Draw("PEX0")
+      canv.SaveAs(f"{outFileDirName}/{histRatio.GetName()}.pdf")
+
+      # overlay H_0^meas(0, 0) and measured intensity distribution; must be identical
+      histIntMeas = ROOT.RDataFrame(treeName, dataFileName) \
+                        .Histo1D(
+                          ROOT.RDF.TH1DModel("intensity_meas", f";{massBinning.axisTitle};Events", *massBinning.astuple), "mass", "eventWeight"
+                        ).GetValue()
+      for binIndex, HMeas in enumerate(H000s[0]):
+        HMeas.truth = histIntMeas.GetBinContent(binIndex + 1)  # set truth values to measured intensity
+      plotMoments(
+        HVals             = H000s[0],
+        binning           = massBinning,
+        normalizedMoments = normalizeMoments,
+        momentLabel       = H000Index.label,
+        pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_meas_intensity_",
+        histTitle         = H000Index.title,
+        legendLabels      = ("Measured Moment", "Measured Intensity"),
+      )
+
+    timer.stop("Total execution time")
+    print(timer.summary)

--- a/momentsPhotoProdPiPiUnpol.py
+++ b/momentsPhotoProdPiPiUnpol.py
@@ -308,7 +308,6 @@ if __name__ == "__main__":
       scaleFactor =   momentResultsPhys[normMassBinIndex][H000Index].val.real \
                     / momentResultsClas[normMassBinIndex][H000Index].val.real
       momentResultsClas.scaleBy(scaleFactor)
-      # print(f"!!!\n{momentResultsPhys[36]}\n!!! vs.\n{momentResultsClas[36]}")
 
       # plot moments in each kinematic bin
       for massBinIndex, HPhys in enumerate(momentResultsPhys):
@@ -325,6 +324,7 @@ if __name__ == "__main__":
           HTrue             = HClas,
           pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{label}_",
           legendLabels      = ("Moment", "CLAS"),
+          plotHTrueUncert   = True,
         )
         plotMomentsInBin(
           HData             = HMeas,
@@ -373,6 +373,7 @@ if __name__ == "__main__":
           pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_",
           histTitle         = qnIndex.title,
           legendLabels      = ("Moment", "CLAS"),
+          plotHTrueUncert   = True,
         )
         plotMoments1D(
           momentResults     = momentResultsMeas,

--- a/testMomentCalculator.py
+++ b/testMomentCalculator.py
@@ -13,9 +13,9 @@ print = functools.partial(print, flush = True)
 
 if __name__ == "__main__":
   momentIndices = MomentCalculator.MomentIndices(maxL = 5, polarized = True)
-  for i in momentIndices.flatIndices():
+  for i in momentIndices.flatIndices:
     print(f"{i} : {momentIndices[i]}")
-  for i in momentIndices.QnIndices():
+  for i in momentIndices.QnIndices:
     print(f"{i} : {momentIndices[i]}")
   qnIndex = MomentCalculator.QnMomentIndex(0, 0, 0)
   print(f"{type(momentIndices._QnIndexByFlatIndex[0])=}, {momentIndices[0]=} vs. {momentIndices[qnIndex]=}")

--- a/testMomentCalculator.py
+++ b/testMomentCalculator.py
@@ -12,7 +12,7 @@ print = functools.partial(print, flush = True)
 
 
 if __name__ == "__main__":
-  momentIndices = MomentCalculator.MomentIndices(maxL = 5, photoProd = True)
+  momentIndices = MomentCalculator.MomentIndices(maxL = 5, polarized = True)
   for i in momentIndices.flatIndices():
     print(f"{i} : {momentIndices[i]}")
   for i in momentIndices.QnIndices():
@@ -20,7 +20,7 @@ if __name__ == "__main__":
   qnIndex = MomentCalculator.QnMomentIndex(0, 0, 0)
   print(f"{type(momentIndices._QnIndexByFlatIndex[0])=}, {momentIndices[0]=} vs. {momentIndices[qnIndex]=}")
   print(f"__str__ = '{momentIndices}' vs. __repr__ = '{repr(momentIndices)}'")
-  momentIndices2 = MomentCalculator.MomentIndices(maxL = 5, photoProd = True)
+  momentIndices2 = MomentCalculator.MomentIndices(maxL = 5, polarized = True)
   print(f"equality: {momentIndices == momentIndices2=}")
   if TYPE_CHECKING:
     a = bd.bidict({0 : qnIndex})

--- a/testMomentCalculator.py
+++ b/testMomentCalculator.py
@@ -15,10 +15,10 @@ if __name__ == "__main__":
   momentIndices = MomentCalculator.MomentIndices(maxL = 5, polarized = True)
   for i in momentIndices.flatIndices:
     print(f"{i} : {momentIndices[i]}")
-  for i in momentIndices.QnIndices:
+  for i in momentIndices.qnIndices:
     print(f"{i} : {momentIndices[i]}")
   qnIndex = MomentCalculator.QnMomentIndex(0, 0, 0)
-  print(f"{type(momentIndices._QnIndexByFlatIndex[0])=}, {momentIndices[0]=} vs. {momentIndices[qnIndex]=}")
+  print(f"{type(momentIndices._qnIndexByFlatIndex[0])=}, {momentIndices[0]=} vs. {momentIndices[qnIndex]=}")
   print(f"__str__ = '{momentIndices}' vs. __repr__ = '{repr(momentIndices)}'")
   momentIndices2 = MomentCalculator.MomentIndices(maxL = 5, polarized = True)
   print(f"equality: {momentIndices == momentIndices2=}")

--- a/testMomentsDiffractive.py
+++ b/testMomentsDiffractive.py
@@ -672,11 +672,11 @@ if __name__ == "__main__":
     nmbEvents         = 1000
     nmbMcEvents       = 1000000
     # formulas for detection efficiency: x = cos(theta), y = phi in [-180, +180] deg
-    efficiencyFormula = "1"  # acc_perfect
+    # efficiencyFormula = "1"  # acc_perfect
     # efficiencyFormula = "2 - x * x"  # acc_1
     # efficiencyFormula = "1 - x * x"  # acc_2
     # efficiencyFormula = "180 * 180 - y * y"  # acc_3
-    # efficiencyFormula = "0.25 + (1 - x * x) * (1 - y * y / (180 * 180))"  # acc_4
+    efficiencyFormula = "0.25 + (1 - x * x) * (1 - y * y / (180 * 180))"  # acc_4
     # efficiencyFormula = "(-4 * ((x + 1) / 2 - 1) * ((x + 1) / 2) * ((x + 1) / 2) * ((x + 1) / 2))"  # Mathematica: PiecewiseExpand[BernsteinBasis[4,3,x]]
     # efficiencyFormula += " * ((((y + 180) / 360) / 3) * (2 * ((y + 180) / 360) * (5 * ((y + 180) / 360) - 9) + 9))"  # PiecewiseExpand[BernsteinBasis[3,1,x]+BernsteinBasis[3,3,x]/3]; acc_5
 

--- a/testMomentsNizar.py
+++ b/testMomentsNizar.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
     # convert MomentResult objects to tuple of dictionaries and write to JSON file
     momentMemberVarsToRemove = ("binCenters", "label", "bsSamples", "uncertRe", "uncertIm")
     HTrueDicts: list[dict[str, Any]] = []
-    for moment in HTrue.values():
+    for moment in HTrue.values:
       HTrueDict = {}
       for key, value in asdict(moment).items():
         if key not in momentMemberVarsToRemove:

--- a/testMomentsPhotoProd.py
+++ b/testMomentsPhotoProd.py
@@ -313,7 +313,7 @@ if __name__ == "__main__":
       label = binLabel(HData)
       plotMomentsInBin(HData = moments[0].HPhys, HTrue = HTrue, pdfFileNamePrefix = f"{outFileDirName}/h{label}_")
     # plot kinematic dependences of all moments #TODO normalize H_0(0, 0) to total number of events
-    for qnIndex in momentIndices.QnIndices():
+    for qnIndex in momentIndices.QnIndices:
       plotMoments1D(
         momentResults     = moments.momentResultsPhys,
         qnIndex           = qnIndex,

--- a/testMomentsPhotoProd.py
+++ b/testMomentsPhotoProd.py
@@ -313,7 +313,7 @@ if __name__ == "__main__":
       label = binLabel(HData)
       plotMomentsInBin(HData = moments[0].HPhys, HTrue = HTrue, pdfFileNamePrefix = f"{outFileDirName}/h{label}_")
     # plot kinematic dependences of all moments #TODO normalize H_0(0, 0) to total number of events
-    for qnIndex in momentIndices.QnIndices:
+    for qnIndex in momentIndices.qnIndices:
       plotMoments1D(
         momentResults     = moments.momentResultsPhys,
         qnIndex           = qnIndex,

--- a/testMomentsPhotoProdEtaPi0.py
+++ b/testMomentsPhotoProdEtaPi0.py
@@ -227,7 +227,7 @@ if __name__ == "__main__":
           plotMomentsInBin(momentsInBin.HMeas, normalizeMoments,                  pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{label}_accPs_", plotLegend = False)
           # plotMomentsInBin(momentsInBin.HPhys, normalizeMoments, HTrue = HTruePs, pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{binLabel}_accPsCorr_")
         # plot kinematic dependences of all phase-space moments
-        for qnIndex in momentIndices.QnIndices:
+        for qnIndex in momentIndices.qnIndices:
           HVals = tuple(MomentValueAndTruth(*momentsInBin.HMeas[qnIndex]) for momentsInBin in moments)
           plotMoments(HVals, massBinning, normalizeMoments, momentLabel = qnIndex.label,
                       pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{massBinning.var.name}_accPs_", histTitle = qnIndex.title, plotLegend = False)
@@ -257,7 +257,7 @@ if __name__ == "__main__":
 
       # plot kinematic dependences of all moments
       pullParameters: Dict[QnMomentIndex, Dict[bool, Tuple[Tuple[float, float], Tuple[float, float]]]] = {} # {index : {isReal : ((mean val, mean err), (sigma val, sigma err))}}
-      for qnIndex in momentIndices.QnIndices:
+      for qnIndex in momentIndices.qnIndices:
         plotMoments1D(
           momentResults     = moments.momentResultsPhys,
           qnIndex           = qnIndex,

--- a/testMomentsPhotoProdEtaPi0.py
+++ b/testMomentsPhotoProdEtaPi0.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
   setupPlotStyle()
   threadController = threadpoolctl.ThreadpoolController()  # at this point all multi-threading libraries must be loaded
   print(f"Initial state of ThreadpoolController before setting number of threads:\n{threadController.info()}")
-  with threadController.limit(limits = 3):
+  with threadController.limit(limits = 5):
     print(f"State of ThreadpoolController after setting number of threads:\n{threadController.info()}")
     timer.start("Total execution time")
 
@@ -103,7 +103,8 @@ if __name__ == "__main__":
     #!Note! partial-wave amplitudes for signal are defined in helicity frame
     # signalPWAmpsFileName = "./dataMcPhotoProdEtaPi0/a0a2_raw/a0a2_complex_amps.csv"
     signalPwAmpsFileName = "./dataMcPhotoProdEtaPi0/a0a2_bin_10_amps.csv"
-    beamPolarization     = 1.0  #TODO read from tree
+    beamPolarization     = None  # unpolarized case
+    # beamPolarization     = 0.0  # read from data
     # maxL                 = 1  # define maximum L quantum number of moments
     maxL                 = 5  # define maximum L quantum number of moments
     normalizeMoments     = False
@@ -118,11 +119,11 @@ if __name__ == "__main__":
     # massBinning          = HistAxisBinning(nmbBins = 2, minVal = 1.28, maxVal = 1.36, _var = binVarMass)
     # massBinning          = HistAxisBinning(nmbBins = 1, minVal = 1.12, maxVal = 1.16, _var = binVarMass)
     # study with constant amplitude values taken from bin 10 at 1.30 GeV
-    massBinning          = HistAxisBinning(nmbBins = 25, minVal = 0.92, maxVal = 1.92, _var = binVarMass)
+    # massBinning          = HistAxisBinning(nmbBins = 25, minVal = 0.92, maxVal = 1.92, _var = binVarMass)
     # massBinning          = HistAxisBinning(nmbBins = 1, minVal = 0.88 , maxVal = 0.92, _var = binVarMass)
-    # massBinning          = HistAxisBinning(nmbBins = 1, minVal = 1.28 , maxVal = 1.32, _var = binVarMass)
+    massBinning          = HistAxisBinning(nmbBins = 1, minVal = 1.28 , maxVal = 1.32, _var = binVarMass)
     # massBinning          = HistAxisBinning(nmbBins = 1, minVal = 0.92 , maxVal = 1.92, _var = binVarMass)
-    nmbOpenMpThreads = ROOT.getNmbOpenMpThreads()
+    nmbOpenMpThreads     = ROOT.getNmbOpenMpThreads()
 
     # load all signal and phase-space data
     print(f"Loading accepted signal data from tree '{treeName}' in file '{signalAccFileName}'")
@@ -171,7 +172,7 @@ if __name__ == "__main__":
         amplitudeSet = AmplitudeSet(amps = readPartialWaveAmplitudes(signalPwAmpsFileName, massBinCenter), tolerance = 1e-11)
         HTrue: MomentResult = amplitudeSet.photoProdMomentSet(maxL, normalize = normalizeMoments, printMomentFormulas = False)
         # scale true moments such that H_0(0, 0) is number of generated signal events
-        scale = nmbSignalGenEvents[-1] / HTrue._valsFlatIndex[0]
+        scale = nmbSignalGenEvents[-1] / HTrue._valsFlatIndex[0]  #TODO get moment value using QnMomentIndex
         HTrue._valsFlatIndex *= scale
         print(f"True moment values:\n{HTrue}")
 

--- a/testMomentsPhotoProdEtaPi0.py
+++ b/testMomentsPhotoProdEtaPi0.py
@@ -103,7 +103,8 @@ if __name__ == "__main__":
     #!Note! partial-wave amplitudes for signal are defined in helicity frame
     # signalPWAmpsFileName = "./dataMcPhotoProdEtaPi0/a0a2_raw/a0a2_complex_amps.csv"
     signalPwAmpsFileName = "./dataMcPhotoProdEtaPi0/a0a2_bin_10_amps.csv"
-    beamPolarization     = None  # unpolarized case
+    beamPolarization     = None  # unpolarized case; note that the data are still polarized we only extract the unpolarized moments neglecting the polarized ones
+                                 # neglecting the polarized moments leads to a bias in the estimated unpolarized moments, because the acceptance correction is slightly off
     # beamPolarization     = 0.0  # read from data
     # maxL                 = 1  # define maximum L quantum number of moments
     maxL                 = 5  # define maximum L quantum number of moments

--- a/testMomentsPhotoProdEtaPi0.py
+++ b/testMomentsPhotoProdEtaPi0.py
@@ -227,7 +227,7 @@ if __name__ == "__main__":
           plotMomentsInBin(momentsInBin.HMeas, normalizeMoments,                  pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{label}_accPs_", plotLegend = False)
           # plotMomentsInBin(momentsInBin.HPhys, normalizeMoments, HTrue = HTruePs, pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{binLabel}_accPsCorr_")
         # plot kinematic dependences of all phase-space moments
-        for qnIndex in momentIndices.QnIndices():
+        for qnIndex in momentIndices.QnIndices:
           HVals = tuple(MomentValueAndTruth(*momentsInBin.HMeas[qnIndex]) for momentsInBin in moments)
           plotMoments(HVals, massBinning, normalizeMoments, momentLabel = qnIndex.label,
                       pdfFileNamePrefix = f"{outFileDirName}/{namePrefix}_{massBinning.var.name}_accPs_", histTitle = qnIndex.title, plotLegend = False)
@@ -257,7 +257,7 @@ if __name__ == "__main__":
 
       # plot kinematic dependences of all moments
       pullParameters: Dict[QnMomentIndex, Dict[bool, Tuple[Tuple[float, float], Tuple[float, float]]]] = {} # {index : {isReal : ((mean val, mean err), (sigma val, sigma err))}}
-      for qnIndex in momentIndices.QnIndices():
+      for qnIndex in momentIndices.QnIndices:
         plotMoments1D(
           momentResults     = moments.momentResultsPhys,
           qnIndex           = qnIndex,


### PR DESCRIPTION
This pull request extends the moment calculations to the unpolarized case. To this end, the meaning of the `None` value of the `polarization` member variable in `DataSet` was redefined. In addition, a script was added that analyses the GlueX pi+pi- data in the same kinematic region as in a CLAS publication. The GlueX results are compared to the CLAS data.